### PR TITLE
Feature/database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# --- MYSQL CONFIGURATION ---
+# MySQL Configurations
+MYSQL_ADDRESS=mysqladdresshere
+MYSQL_DB_NAME=databasenamehere
+MYSQL_ROOT_PASSWORD=rootpasswordhere
+# Admin User Configurations
+ADMIN_SQL_USER=adminuserformysqlname
+ADMIN_SQL_PASSWORD=adminuserforsqlpassword
+# Application/Service User Configurations
+APP_USER=appserviceusername
+APP_PASSWORD=appserviceuserpassword
+
+# --- SERVER CONFIGURATION ---
+GIN_MODE=debug
+PORT=8080
+
+VITE_API_BASE_URL=frontendclientbaseurlhere
+VITE_CLIENT_ID=uuidforfrontendclient
+VITE_REDIRECT_URI=frontendclientredirecthere
+VITE_CLIENT_SECRET=passwordforfrontendclienthere
+VITE_BACKEND_URL=backendurlhere

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Iskolutions-Capstone-Dev-Team/One-Portal/internal/initializers"
 	"github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
 )
@@ -18,6 +19,9 @@ const TimeOutDuration = 5 * time.Second
 func main() {
 	// Load environment variables from .env file
 	godotenv.Load()
+
+	// Run database migrations and seed initial data
+	initializers.MigrateAndSeed()
 
 	// Create a context that listens for interrupt signals
 	ctx, stop := signal.NotifyContext(
@@ -49,7 +53,7 @@ func main() {
 
 	// Create a context with timeout for the shutdown process
 	shutdownCtx, cancel := context.WithTimeout(
-		context.Background(), 
+		context.Background(),
 		TimeOutDuration,
 	)
 	defer cancel()

--- a/backend/internal/database/connection.go
+++ b/backend/internal/database/connection.go
@@ -1,0 +1,70 @@
+package database
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/jmoiron/sqlx"
+)
+
+func ConnectAdminToDB() (*sqlx.DB, error) {
+	// Implementation for connecting to the database as admin for migration
+	var err error
+	config := mysql.Config{
+		User:                 os.Getenv("ADMIN_SQL_USER"),
+		Passwd:               os.Getenv("ADMIN_SQL_PASSWORD"),
+		Net:                  "tcp",
+		Addr:                 os.Getenv("MYSQL_ADDRESS"),
+		DBName:               os.Getenv("MYSQL_DB_NAME"),
+		AllowNativePasswords: true,
+		ParseTime:            true,
+		MultiStatements:      true,
+	}
+
+	db, err := sqlx.Open("mysql", config.FormatDSN())
+	if err != nil {
+		return nil, fmt.Errorf("Error connecting to database: %w", err)
+	}
+
+	return db, nil
+}
+
+func ConnectToDB() (*sqlx.DB, error) {
+	// Implementation for connecting to the database as the application service
+	var err error
+	config := mysql.Config{
+		User:                 os.Getenv("APP_USER"),
+		Passwd:               os.Getenv("APP_PASSWORD"),
+		Net:                  "tcp",
+		Addr:                 os.Getenv("MYSQL_ADDRESS"),
+		DBName:               os.Getenv("MYSQL_DB_NAME"),
+		AllowNativePasswords: true,
+		ParseTime:            true,
+	}
+
+	db, err := sqlx.Open("mysql", config.FormatDSN())
+	if err != nil {
+		return nil, fmt.Errorf("Error connecting to database: %w", err)
+	}
+
+	maxConnections := 25
+	maxLifetime := 5 * time.Minute
+
+	db.SetMaxOpenConns(maxConnections)
+	db.SetMaxIdleConns(maxConnections)
+	db.SetConnMaxLifetime(maxLifetime)
+
+	if err = db.Ping(); err != nil {
+		db.Close()
+
+		return nil, fmt.Errorf(
+			"Error pinging the database at %s: %w", 
+			config.Addr, 
+			err,
+		)
+	}
+
+	return db, nil
+}

--- a/backend/internal/database/migrate.go
+++ b/backend/internal/database/migrate.go
@@ -1,0 +1,65 @@
+package database
+
+import (
+	"log"
+
+	"github.com/Iskolutions-Capstone-Dev-Team/One-Portal/internal/database/migrations"
+	"github.com/Iskolutions-Capstone-Dev-Team/One-Portal/internal/database/migrations/tables"
+	"github.com/jmoiron/sqlx"
+)
+
+func executeTableMigration(db *sqlx.DB, migration migrations.TableMigration) {
+	for _, step := range migration.Steps {
+		// 1. Check if this specific step ID has already been executed
+		var count int
+		query := "SELECT COUNT(*) FROM migration_history WHERE migration_id = ?"
+		err := db.Get(&count, query, step.ID)
+		if err != nil {
+			// If the history table doesn't exist yet, we'll need to handle that
+			// (usually by creating it at the very start of RunMigrations)
+			log.Fatalf("Failed to check migration history: %v", err)
+		}
+
+		// 2. If count is 0, the step has never run
+		if count == 0 {
+			log.Printf("[MIGRATE] Applying step: %s", step.ID)
+
+			// Execute the SQL (Create table, Alter table, etc.)
+			db.MustExec(step.SQL)
+
+			// 3. Record that this step is now finished
+			db.MustExec(
+				"INSERT INTO migration_history (migration_id) VALUES (?)",
+				step.ID,
+			)
+		} else {
+			log.Printf("[MIGRATE] Skipping completed step: %s", step.ID)
+		}
+	}
+}
+
+func RunAllMigrations(db *sqlx.DB) {
+	log.Println("[MIGRATE] Initializing migration history...")
+	db.MustExec(`CREATE TABLE IF NOT EXISTS migration_history (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        migration_id VARCHAR(255) NOT NULL UNIQUE,
+        applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    );`)
+
+	parentTables := []migrations.TableMigration{
+		tables.UsersMigration,
+	}
+
+	childTables := []migrations.TableMigration{
+		tables.SessionsMigration,
+		tables.LogsMigration,
+		tables.RefreshTokensMigration,
+	}
+
+	allMigrations := append(parentTables, childTables...)
+	for _, m := range allMigrations {
+		executeTableMigration(db, m)
+	}
+
+	log.Println("[MIGRATE] All tables and procedures are synchronized.")
+}

--- a/backend/internal/database/migrations/tables/logs_table.go
+++ b/backend/internal/database/migrations/tables/logs_table.go
@@ -1,0 +1,19 @@
+package tables
+
+import "github.com/Iskolutions-Capstone-Dev-Team/One-Portal/internal/database/migrations"
+
+var LogsMigration = migrations.TableMigration{
+	TableName: "logs",
+	Steps: []migrations.MigrationStep{
+		{
+			ID: "create-logs-table",
+			SQL: `
+			 CREATE TABLE IF NOT EXISTS logs (
+				id BIGINT AUTO_INCREMENT PRIMARY KEY,
+				actor VARCHAR(100),
+				action VARCHAR(100) NOT NULL,
+				created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+			);`,
+		},
+	},
+}

--- a/backend/internal/database/migrations/tables/refresh_tokens.go
+++ b/backend/internal/database/migrations/tables/refresh_tokens.go
@@ -1,0 +1,20 @@
+package tables
+
+import "github.com/Iskolutions-Capstone-Dev-Team/One-Portal/internal/database/migrations"
+
+var RefreshTokensMigration = migrations.TableMigration{
+	TableName: "refresh_tokens",
+	Steps: []migrations.MigrationStep{
+		{
+			ID: "create-refresh-tokens-table",
+			SQL: `CREATE TABLE IF NOT EXISTS refresh_tokens (
+				token VARCHAR(255) PRIMARY KEY,
+				user_id BINARY(16) NOT NULL,
+				expires_at TIMESTAMP NOT NULL,
+				created_at TIMESTAMP DEFAULT NOW(),
+				updated_at TIMESTAMP DEFAULT NOW() ON UPDATE NOW(),
+				FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+			);`,
+		},
+	},
+}

--- a/backend/internal/database/migrations/tables/sessions_table.go
+++ b/backend/internal/database/migrations/tables/sessions_table.go
@@ -1,0 +1,20 @@
+package tables
+
+import "github.com/Iskolutions-Capstone-Dev-Team/One-Portal/internal/database/migrations"
+
+var SessionsMigration = migrations.TableMigration{
+	TableName: "sessions",
+	Steps: []migrations.MigrationStep{
+		{
+			ID: "create-sessions-table",
+			SQL: `CREATE TABLE IF NOT EXISTS sessions (
+				session_id VARCHAR(255) PRIMARY KEY,
+				user_id BINARY(16) NOT NULL,
+				expires_at TIMESTAMP NOT NULL,
+				created_at TIMESTAMP DEFAULT NOW(),
+				updated_at TIMESTAMP DEFAULT NOW() ON UPDATE NOW(),
+				FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+			);`,
+		},
+	},
+}

--- a/backend/internal/database/migrations/tables/users_table.go
+++ b/backend/internal/database/migrations/tables/users_table.go
@@ -1,0 +1,24 @@
+package tables
+
+import "github.com/Iskolutions-Capstone-Dev-Team/One-Portal/internal/database/migrations"
+
+var UsersMigration = migrations.TableMigration{
+	TableName: "users",
+	Steps: []migrations.MigrationStep{
+		{
+			ID: "create-users-table",
+			SQL: `CREATE TABLE IF NOT EXISTS users (
+				id BINARY(16) PRIMARY KEY,
+				username VARCHAR(255) NOT NULL UNIQUE,
+				first_name VARCHAR(50),
+				middle_name VARCHAR(50),
+				last_name VARCHAR(50),
+				name_suffix VARCHAR(10),
+				email VARCHAR(100) NOT NULL UNIQUE,
+				created_at TIMESTAMP DEFAULT NOW(),
+				updated_at TIMESTAMP DEFAULT NOW() ON UPDATE NOW(),
+				last_login TIMESTAMP NULL
+			);`,
+		},
+	},
+}

--- a/backend/internal/database/migrations/types.go
+++ b/backend/internal/database/migrations/types.go
@@ -1,0 +1,16 @@
+package migrations
+
+type MigrationPart struct {
+	Name string
+	SQL  string
+}
+
+type MigrationStep struct {
+	ID  string 
+	SQL string
+}
+
+type TableMigration struct {
+	TableName string
+	Steps     []MigrationStep
+}

--- a/backend/internal/initializers/seed.go
+++ b/backend/internal/initializers/seed.go
@@ -1,0 +1,55 @@
+package initializers
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/Iskolutions-Capstone-Dev-Team/One-Portal/internal/database"
+	"github.com/jmoiron/sqlx"
+)
+
+/**
+ * Migrate handles the database schema updates and initial data seeding.
+ * It uses administrative privileges to ensure schema changes are permitted.
+ */
+func MigrateAndSeed() {
+	adminDatabase, err := database.ConnectAdminToDB()
+	if err != nil {
+		log.Fatalf("[Migrate] Admin Connection Failed: %v", err)
+	}
+	defer adminDatabase.Close()
+
+	database.RunAllMigrations(adminDatabase)
+	fmt.Println("Database migration completed successfully.")
+
+	privilegedTables := [...]string{
+		"refresh_tokens",
+		"sessions",
+	}
+
+	for _, tableName := range privilegedTables {
+		err = grantDeleteOnTable(tableName, adminDatabase)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+
+func grantDeleteOnTable(tableName string, db *sqlx.DB) error {
+	databaseName := os.Getenv("MYSQL_DB_NAME")
+	appUser := os.Getenv("APP_USER")
+
+	query := fmt.Sprintf(
+		"GRANT DELETE ON `%s`.`%s` TO '%s'@'%%'; FLUSH PRIVILEGES;",
+		databaseName,
+		tableName,
+		appUser,
+	)
+
+	_, err := db.Exec(query)
+	if err != nil {
+		return fmt.Errorf("[GrantDeleteOnTable] {Query}: %v", err)
+	}
+	return nil
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
         max-file: "3"
 
 # Database Application
-  db:
+  oneportal_database:
     image: mysql:8.4
     container_name: unified_access_database
     restart: always

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+mysql -u root -p"$MYSQL_ROOT_PASSWORD" <<-EOSQL
+    -- 1. Create and Configure Admin User
+    CREATE USER IF NOT EXISTS '${ADMIN_SQL_USER}'@'%' 
+    IDENTIFIED BY '${ADMIN_SQL_PASSWORD}';
+
+    GRANT ALL PRIVILEGES ON *.* TO '${ADMIN_SQL_USER}'@'%' WITH GRANT OPTION;
+    
+    -- 2. Create and Configure Application Service User
+    CREATE USER IF NOT EXISTS '${APP_USER}'@'%' 
+    IDENTIFIED BY '${APP_PASSWORD}';
+
+    -- General permissions for the IdP Backend
+    GRANT SELECT, INSERT, UPDATE, EXECUTE ON \`${MYSQL_DB_NAME}\`.* TO '${APP_USER}'@'%';
+
+    FLUSH PRIVILEGES;
+EOSQL
+
+echo "[Database Init] Users '${ADMIN_SQL_USER}' and '${APP_USER}' configured."


### PR DESCRIPTION
This pull request introduces a robust database migration and initialization system for the backend, including environment variable configuration, database connection utilities, migration tracking, and initial user privilege setup. It also adds migration definitions for core tables and ensures proper seeding and privilege granting during startup.

**Database Configuration and Connection:**

- Added a comprehensive `.env.example` file with variables for MySQL and server configuration, including separate credentials for admin and application users.
- Implemented `ConnectAdminToDB` and `ConnectToDB` functions in `backend/internal/database/connection.go` to handle connections as either the admin or application user, with connection pooling and error handling.

**Database Migration System:**

- Introduced a migration system in `backend/internal/database/migrate.go` that tracks executed migrations in a `migration_history` table and applies new migrations for all core tables.
- Defined migration types and structures in `backend/internal/database/migrations/types.go` to standardize migration steps and table migrations.
- Added migration definitions for `users`, `sessions`, `logs`, and `refresh_tokens` tables, each with their own migration file under `backend/internal/database/migrations/tables/`. [[1]](diffhunk://#diff-8161ca0d8dac95be8dd2bb871b8b4df211217f7faff248ad9a9399a5b1b5c72aR1-R24) [[2]](diffhunk://#diff-7877b882bf73e33589133572df127ee329c3b1328f4949eb9940cd21ef1e3544R1-R20) [[3]](diffhunk://#diff-f084bb8c4c97f81272088f2eee33656bbe5a8418ff58a02b0ceb0adcd5d7839eR1-R19) [[4]](diffhunk://#diff-e477106add4e8ffc01dc50de88729f9a5cebcbadea6b1baf060206c7b534b14aR1-R20)

**Initialization and Seeding:**

- Created `MigrateAndSeed` in `backend/internal/initializers/seed.go` to run all migrations and grant necessary DELETE privileges to the application user for sensitive tables.
- Updated `backend/cmd/main.go` to run `MigrateAndSeed` at startup, ensuring the database schema is up-to-date before the application starts. [[1]](diffhunk://#diff-26655dfbf33b31bc9c17ec7f3f1577743aac89c6c3fcc6c1e5e0bc23e9c15fb4R12) [[2]](diffhunk://#diff-26655dfbf33b31bc9c17ec7f3f1577743aac89c6c3fcc6c1e5e0bc23e9c15fb4R23-R25)

**Deployment and Setup:**

- Added `scripts/init.sh` to automate the creation and configuration of MySQL admin and application users, granting appropriate privileges.
- Updated the database service name in `docker-compose.yml` from `db` to `oneportal_database` for clarity and consistency.