### PR TITLE
Fix/logout

### DIFF
--- a/backend/internal/api/v1/auth_handler.go
+++ b/backend/internal/api/v1/auth_handler.go
@@ -55,23 +55,28 @@ func NewAuthHandler(
 // @Router       /auth/authorize [get]
 func (h *AuthHandler) HandleAuthorization(c *gin.Context) {
 	authorizeBaseURL := os.Getenv("IDP_AUTH_URL")
-	clientID := os.Getenv("VITE_CLIENT_ID")
-	authorizeURL := fmt.Sprintf("%s?client_id=%s", authorizeBaseURL, clientID)
-	resp, err := Client.Get(authorizeURL)
-	if err != nil {
-		log.Printf(
-			"[HandleAuthorization] Failed to redirect: %v",
-			err,
-		)
+	clientID := os.Getenv("CLIENT_ID")
+	redirectURI := os.Getenv("VITE_REDIRECT_URI")
+
+	if authorizeBaseURL == "" || clientID == "" || redirectURI == "" {
+		log.Printf("[HandleAuthorization] Config: missing env variables")
 		c.JSON(
 			http.StatusInternalServerError,
 			dto.ErrorResponse{
-				Error: "Authorization redirect failed",
+				Error: "Authorization configuration failed",
 			},
 		)
 		return
 	}
-	defer resp.Body.Close()
+
+	authorizeURL := fmt.Sprintf(
+		"%s?client_id=%s&redirect_uri=%s&response_type=code",
+		authorizeBaseURL,
+		clientID,
+		redirectURI,
+	)
+
+	c.Redirect(http.StatusFound, authorizeURL)
 }
 
 // HandleCallback handles the callback from the IDP after successful auth.
@@ -100,8 +105,8 @@ func (h *AuthHandler) HandleCallback(c *gin.Context) {
 	}
 
 	payload, err := json.Marshal(dto.CallbackPayload{
-		ClientID:     os.Getenv("VITE_CLIENT_ID"),
-		ClientSecret: os.Getenv("VITE_CLIENT_SECRET"),
+		ClientID:     os.Getenv("CLIENT_ID"),
+		ClientSecret: os.Getenv("CLIENT_SECRET"),
 		Code:         req.Code,
 	})
 	if err != nil {
@@ -461,7 +466,7 @@ func (h *AuthHandler) processTokenDeletion(c *gin.Context, tokenStr string) {
 // notifyIDPLogout sends a logout notification to the IDP.
 func (h *AuthHandler) notifyIDPLogout(c *gin.Context) string {
 	logoutURL := os.Getenv("IDP_LOGOUT_URL")
-	clientID := os.Getenv("VITE_CLIENT_ID")
+	clientID := os.Getenv("CLIENT_ID")
 	if logoutURL == "" || clientID == "" {
 		return ""
 	}

--- a/backend/internal/api/v1/auth_handler.go
+++ b/backend/internal/api/v1/auth_handler.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -277,9 +278,9 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 	c.SetCookie(dto.AccessCookieName, "", -1, "/", "", true, true)
 
 	// Notify the Identity Provider about the logout
-	h.notifyIDPLogout()
+	url := h.notifyIDPLogout(c)
 
-	c.JSON(http.StatusOK, gin.H{"status": "logged out"})
+	c.JSON(http.StatusOK, gin.H{"url": url})
 }
 
 // HandleRefresh handles requesting new access and refresh tokens from the IDP.
@@ -448,22 +449,32 @@ func (h *AuthHandler) processTokenDeletion(c *gin.Context, tokenStr string) {
 }
 
 // notifyIDPLogout sends a logout notification to the IDP.
-func (h *AuthHandler) notifyIDPLogout() {
+func (h *AuthHandler) notifyIDPLogout(c *gin.Context) string {
 	logoutURL := os.Getenv("IDP_LOGOUT_URL")
 	clientID := os.Getenv("VITE_CLIENT_ID")
 	if logoutURL == "" || clientID == "" {
-		return
+		return ""
 	}
 
-	payload, _ := json.Marshal(map[string]string{
-		"client_id": clientID,
-	})
-	_, err := Client.Post(
-		logoutURL,
-		"application/json",
-		bytes.NewBuffer(payload),
-	)
-	if err != nil {
-		log.Printf("[Logout] IDP Logout Request: %v", err)
+	accessToken, _ := c.Cookie(dto.AccessCookieName)
+	if accessToken == "" {
+		return logoutURL
 	}
+
+	claims, err := middleware.ValidateAccessToken(accessToken)
+	if err != nil {
+		return logoutURL
+	}
+
+	userID, ok := claims["userId"].(string)
+	if !ok {
+		return logoutURL
+	}
+
+	return fmt.Sprintf(
+		"%s?client_id=%s&user_id=%s",
+		logoutURL,
+		clientID,
+		userID,
+	)
 }

--- a/backend/internal/api/v1/auth_handler.go
+++ b/backend/internal/api/v1/auth_handler.go
@@ -54,7 +54,9 @@ func NewAuthHandler(
 // @Failure      500  {object}  dto.ErrorResponse
 // @Router       /auth/authorize [get]
 func (h *AuthHandler) HandleAuthorization(c *gin.Context) {
-	authorizeURL := os.Getenv("IDP_AUTH_URL")
+	authorizeBaseURL := os.Getenv("IDP_AUTH_URL")
+	clientID := os.Getenv("VITE_CLIENT_ID")
+	authorizeURL := fmt.Sprintf("%s?client_id=%s", authorizeBaseURL, clientID)
 	resp, err := Client.Get(authorizeURL)
 	if err != nil {
 		log.Printf(

--- a/backend/internal/api/v1/auth_handler.go
+++ b/backend/internal/api/v1/auth_handler.go
@@ -279,8 +279,16 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 
 	// Notify the Identity Provider about the logout
 	url := h.notifyIDPLogout(c)
+	if url != "" {
+		resp, err := Client.Get(url)
+		if err != nil {
+			log.Printf("[Logout] IDP Notification: %v", err)
+		} else {
+			resp.Body.Close()
+		}
+	}
 
-	c.JSON(http.StatusOK, gin.H{"url": url})
+	c.Status(http.StatusOK)
 }
 
 // HandleRefresh handles requesting new access and refresh tokens from the IDP.

--- a/backend/internal/api/v1/auth_handler.go
+++ b/backend/internal/api/v1/auth_handler.go
@@ -283,6 +283,7 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 
 	// Always clear the access token cookie
 	c.SetCookie(dto.AccessCookieName, "", -1, "/", "", true, true)
+	c.SetCookie(dto.SessionCookieName, "", -1, "/", "", true, true)
 
 	// Notify the Identity Provider about the logout
 	url := h.notifyIDPLogout(c)

--- a/backend/internal/api/v1/auth_handler.go
+++ b/backend/internal/api/v1/auth_handler.go
@@ -76,7 +76,7 @@ func (h *AuthHandler) HandleAuthorization(c *gin.Context) {
 		redirectURI,
 	)
 
-	c.Redirect(http.StatusFound, authorizeURL)
+	c.JSON(http.StatusOK, gin.H{"url": authorizeURL})
 }
 
 // HandleCallback handles the callback from the IDP after successful auth.

--- a/backend/internal/api/v1/auth_handler.go
+++ b/backend/internal/api/v1/auth_handler.go
@@ -279,16 +279,8 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 
 	// Notify the Identity Provider about the logout
 	url := h.notifyIDPLogout(c)
-	if url != "" {
-		resp, err := Client.Get(url)
-		if err != nil {
-			log.Printf("[Logout] IDP Notification: %v", err)
-		} else {
-			resp.Body.Close()
-		}
-	}
 
-	c.Status(http.StatusOK)
+	c.JSON(http.StatusOK, gin.H{"url": url})
 }
 
 // HandleRefresh handles requesting new access and refresh tokens from the IDP.

--- a/backend/internal/api/v1/auth_handler.go
+++ b/backend/internal/api/v1/auth_handler.go
@@ -279,6 +279,14 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 
 	// Notify the Identity Provider about the logout
 	url := h.notifyIDPLogout(c)
+	if url != "" {
+		resp, err := Client.Get(url)
+		if err != nil {
+			log.Printf("[Logout] IDP Notification: %v", err)
+		} else {
+			resp.Body.Close()
+		}
+	}
 
 	c.JSON(http.StatusOK, gin.H{"url": url})
 }

--- a/backend/internal/dto/auth_dto.go
+++ b/backend/internal/dto/auth_dto.go
@@ -33,4 +33,7 @@ type JWK struct {
 	Y   string `json:"y"`
 }
 
-const AccessCookieName = "access_token"
+const (
+	AccessCookieName  = "access_token"
+	SessionCookieName = "session_cookie"
+)

--- a/backend/internal/tests/handler/auth_handler_test.go
+++ b/backend/internal/tests/handler/auth_handler_test.go
@@ -146,9 +146,9 @@ func TestAuthHandlerLogout(t *testing.T) {
 
 	// Mock IDP logout
 	os.Setenv("IDP_LOGOUT_URL", "http://idp/logout")
-	os.Setenv("VITE_CLIENT_ID", "test-client")
+	os.Setenv("CLIENT_ID", "test-client")
 	defer os.Unsetenv("IDP_LOGOUT_URL")
-	defer os.Unsetenv("VITE_CLIENT_ID")
+	defer os.Setenv("CLIENT_ID", "")
 
 	// Set fake transport to capture IDP call
 	origTransport := v1.Client.Transport
@@ -203,7 +203,8 @@ func TestAuthHandlerLogout(t *testing.T) {
 	// 3. Check if IDP was notified
 	if fTripper.lastRequest == nil {
 		t.Error("expected IDP logout notification")
-	} else if fTripper.lastRequest.URL.String() != "http://idp/logout" {
+	} else if !bytes.HasPrefix([]byte(fTripper.lastRequest.URL.String()), 
+		[]byte("http://idp/logout")) {
 		t.Errorf("wrong IDP URL: %s", fTripper.lastRequest.URL.String())
 	}
 }
@@ -213,12 +214,13 @@ func TestAuthHandlerHandleAuthorization(t *testing.T) {
 	router, key := setupTestRouter(authSvc)
 
 	os.Setenv("IDP_AUTH_URL", "http://idp/auth")
-	defer os.Unsetenv("IDP_AUTH_URL")
-
-	origTransport := v1.Client.Transport
-	fTripper := &fakeRoundTripper{}
-	v1.Client.Transport = fTripper
-	defer func() { v1.Client.Transport = origTransport }()
+	os.Setenv("CLIENT_ID", "test-client")
+	os.Setenv("VITE_REDIRECT_URI", "http://app/callback")
+	defer func() {
+		os.Unsetenv("IDP_AUTH_URL")
+		os.Unsetenv("CLIENT_ID")
+		os.Unsetenv("VITE_REDIRECT_URI")
+	}()
 
 	req := httptest.NewRequest(
 		http.MethodGet, 
@@ -230,16 +232,14 @@ func TestAuthHandlerHandleAuthorization(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	// Since current implementation just does Client.Get and does not return
-	// content to ctx, we expect 200 but mostly check if the IDP was called.
-	if w.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d", w.Code)
+	// Implementation now returns 302 redirect
+	if w.Code != http.StatusFound {
+		t.Errorf("expected 302, got %d", w.Code)
 	}
 
-	if fTripper.lastRequest == nil {
-		t.Fatal("expected IDP auth call")
-	}
-	if fTripper.lastRequest.URL.String() != "http://idp/auth" {
-		t.Errorf("expected http://idp/auth, got %s", fTripper.lastRequest.URL.String())
+	loc := w.Header().Get("Location")
+	expectedPrefix := "http://idp/auth?client_id=test-client"
+	if !bytes.HasPrefix([]byte(loc), []byte(expectedPrefix)) {
+		t.Errorf("expected prefix %s, got %s", expectedPrefix, loc)
 	}
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,24 +1,20 @@
-import { BrowserRouter, Route, Routes, useSearchParams } from "react-router-dom";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 import Callback from "./pages/Callback";
 import Home from "./pages/Home";
+import Landing from "./pages/Landing";
+import Login from "./pages/Login";
 import Profile from "./pages/Profile";
 import { PortalThemeProvider } from "./context/PortalThemeContext";
-
-function HomeRoute() {
-  const [searchParams] = useSearchParams();
-  const hasAuthorizationParams = searchParams.has("code") || searchParams.has("error");
-
-  return hasAuthorizationParams ? <Callback /> : <Home />;
-}
 
 export default function App() {
   return (
     <PortalThemeProvider>
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<HomeRoute />} />
+          <Route path="/" element={<Landing />} />
+          <Route path="/login" element={<Login />} />
           <Route path="/callback" element={<Callback />} />
-          <Route path="/portal" element={<HomeRoute />} />
+          <Route path="/portal" element={<Home />} />
           <Route path="/profile" element={<Profile />} />
         </Routes>
       </BrowserRouter>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Route, Routes, useSearchParams } from "react-router-dom";
 import Callback from "./pages/Callback";
 import Home from "./pages/Home";
 import Landing from "./pages/Landing";
@@ -6,12 +6,20 @@ import Login from "./pages/Login";
 import Profile from "./pages/Profile";
 import { PortalThemeProvider } from "./context/PortalThemeContext";
 
+function LandingRoute() {
+  const [searchParams] = useSearchParams();
+  const hasAuthorizationParams = searchParams.has("code") || searchParams.has("error");
+
+  return hasAuthorizationParams ? <Callback /> : <Landing />;
+}
+
 export default function App() {
   return (
     <PortalThemeProvider>
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<Landing />} />
+          <Route path="/" element={<LandingRoute />} />
+          <Route path="/landingRoute" element={<LandingRoute />} />
           <Route path="/login" element={<Login />} />
           <Route path="/callback" element={<Callback />} />
           <Route path="/portal" element={<Home />} />

--- a/frontend/src/layouts/OnePortalLayout.jsx
+++ b/frontend/src/layouts/OnePortalLayout.jsx
@@ -3,7 +3,7 @@ import PortalNavbar from "../components/dashboard/PortalNavbar";
 import PortalFooter from "../components/dashboard/PortalFooter";
 import FloatingActionMenu from "../components/FloatingActionMenu";
 import { usePortalTheme } from "../context/PortalThemeContext";
-import { clearSessionRefreshTimestamp, getLoginPageUrl, getSessionRefreshDelay, refreshSession } from "../services/auth";
+import { clearSessionRefreshTimestamp, getSessionRefreshDelay, refreshSession, startAuthorization } from "../services/auth";
 
 const REFRESH_INTERVAL_MS = 10 * 60 * 1000;
 const SKELETON_CARDS = Array.from({ length: 6 });
@@ -133,7 +133,13 @@ export default function OnePortalLayout({ children }) {
 
                 if (error.status === 401) {
                     clearSessionRefreshTimestamp();
-                    window.location.assign(getLoginPageUrl());
+
+                    try {
+                        await startAuthorization();
+                    } catch (authorizationError) {
+                        console.error("Failed to redirect to the authorization flow.", authorizationError);
+                    }
+
                     return;
                 }
 

--- a/frontend/src/layouts/OnePortalLayout.jsx
+++ b/frontend/src/layouts/OnePortalLayout.jsx
@@ -3,7 +3,7 @@ import PortalNavbar from "../components/dashboard/PortalNavbar";
 import PortalFooter from "../components/dashboard/PortalFooter";
 import FloatingActionMenu from "../components/FloatingActionMenu";
 import { usePortalTheme } from "../context/PortalThemeContext";
-import { clearSessionRefreshTimestamp, getSessionRefreshDelay, refreshSession, startAuthorization } from "../services/auth";
+import { clearSessionRefreshTimestamp, getSessionRefreshDelay, navigateToLoginPage, refreshSession } from "../services/auth";
 
 const REFRESH_INTERVAL_MS = 10 * 60 * 1000;
 const SKELETON_CARDS = Array.from({ length: 6 });
@@ -133,13 +133,7 @@ export default function OnePortalLayout({ children }) {
 
                 if (error.status === 401) {
                     clearSessionRefreshTimestamp();
-
-                    try {
-                        await startAuthorization();
-                    } catch (authorizationError) {
-                        console.error("Failed to redirect to the authorization flow.", authorizationError);
-                    }
-
+                    navigateToLoginPage();
                     return;
                 }
 

--- a/frontend/src/layouts/OnePortalLayout.jsx
+++ b/frontend/src/layouts/OnePortalLayout.jsx
@@ -1,178 +1,47 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import PortalNavbar from "../components/dashboard/PortalNavbar";
 import PortalFooter from "../components/dashboard/PortalFooter";
 import FloatingActionMenu from "../components/FloatingActionMenu";
 import { usePortalTheme } from "../context/PortalThemeContext";
-import { clearSessionRefreshTimestamp, getSessionRefreshDelay, navigateToLoginPage, refreshSession } from "../services/auth";
+import { clearSessionRefreshTimestamp, getSessionRefreshDelay, refreshSession } from "../services/auth";
 
 const REFRESH_INTERVAL_MS = 10 * 60 * 1000;
-const SKELETON_CARDS = Array.from({ length: 6 });
-const SKELETON_PAGES = Array.from({ length: 4 });
-
-function PortalLayoutSkeleton() {
-    return (
-        <div className="portal-home portal-home--loading" aria-busy="true" aria-live="polite">
-            <span className="sr-only">Checking your session</span>
-
-            <header className="portal-header portal-loading__header" aria-hidden="true">
-                <span className="portal-header__glow portal-header__glow--left" />
-                <span className="portal-header__glow portal-header__glow--right" />
-
-                <div className="portal-home__shell">
-                    <div className="portal-header__inner">
-                        <div className="portal-header__brand">
-                            <span className="portal-loading__logo portal-loading__block" />
-
-                            <div className="portal-header__text portal-loading__stack portal-loading__stack--brand">
-                                <span className="portal-loading__line portal-loading__line--brand portal-loading__block" />
-                                <span className="portal-loading__line portal-loading__line--subbrand portal-loading__block" />
-                            </div>
-                        </div>
-
-                        <div className="portal-header__actions">
-                            <span className="portal-loading__header-button portal-loading__block" />
-                            <span className="portal-loading__header-button portal-loading__block" />
-                        </div>
-                    </div>
-                </div>
-            </header>
-
-            <section className="header portal-loading__hero" aria-hidden="true">
-                <div className="header-background">
-                    <img src="/assets/images/pup_bg.png" alt="" aria-hidden="true" className="header-bg-img" />
-                    <div className="header-backdrop" aria-hidden="true" />
-
-                    <div className="header-content">
-                        <div className="header-content__shell portal-loading__hero-shell">
-                            <div className="header-logos">
-                                <span className="portal-loading__hero-logo portal-loading__block" />
-                            </div>
-
-                            <div className="portal-loading__hero-copy">
-                                <span className="portal-loading__hero-title portal-loading__block" />
-                                <span className="portal-loading__hero-subtitle portal-loading__block" />
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </section>
-
-            <main className="portal-home__main portal-home__main--loading">
-                <div className="portal-home__shell portal-loading">
-                    <section className="portal-toolbar portal-loading__toolbar" aria-hidden="true">
-                        <div className="portal-toolbar__copy portal-loading__stack portal-loading__stack--wide">
-                            <span className="portal-loading__line portal-loading__line--toolbar-title portal-loading__block" />
-                            <span className="portal-loading__line portal-loading__line--toolbar-copy portal-loading__block" />
-                            <span className="portal-loading__line portal-loading__line--toolbar-copy-short portal-loading__block" />
-                        </div>
-
-                        <div className="portal-toolbar__search">
-                            <span className="portal-loading__search portal-loading__block" />
-                        </div>
-                    </section>
-
-                    <section className="portal-systems portal-loading__grid" aria-hidden="true">
-                        {SKELETON_CARDS.map((_, index) => (
-                            <article key={index} className="system-card portal-loading__card">
-                                <figure className="system-card-media">
-                                    <div className="portal-loading__card-media portal-loading__block" />
-                                </figure>
-
-                                <div className="system-card__body portal-loading__card-body">
-                                    <span className="portal-loading__line portal-loading__line--card-title portal-loading__block" />
-                                    <span className="portal-loading__line portal-loading__line--card-copy portal-loading__block" />
-                                    <span className="portal-loading__line portal-loading__line--card-copy portal-loading__line--card-copy-wide portal-loading__block" />
-                                    <span className="portal-loading__line portal-loading__line--card-copy-short portal-loading__block" />
-                                    <span className="portal-loading__button portal-loading__block" />
-                                </div>
-                            </article>
-                        ))}
-                    </section>
-
-                    <div className="portal-pagination portal-loading__pagination" aria-hidden="true">
-                        {SKELETON_PAGES.map((_, index) => (
-                            <span
-                                key={index}
-                                className={`portal-loading__page portal-loading__block ${index === 0 ? "is-active" : ""}`}
-                            />
-                        ))}
-                    </div>
-                </div>
-            </main>
-
-            <div className="portal-loading__floating" aria-hidden="true">
-                <span className="portal-loading__floating-badge portal-loading__block" />
-                <span className="portal-loading__floating-button portal-loading__block" />
-            </div>
-        </div>
-    );
-}
 
 export default function OnePortalLayout({ children }) {
     const { theme } = usePortalTheme();
-    const [isSessionReady, setIsSessionReady] = useState(() => getSessionRefreshDelay(REFRESH_INTERVAL_MS) > 0);
 
     useEffect(() => {
-        let isMounted = true;
-        let intervalId;
-        let timeoutId;
+        let intervalId = 0;
+        let timeoutId = 0;
 
-        const initialDelay = getSessionRefreshDelay(REFRESH_INTERVAL_MS);
-
-        const syncSession = async (showLoadingState = false) => {
-            if (isMounted && showLoadingState) {
-                setIsSessionReady(false);
-            }
-
+        const syncSession = async () => {
             try {
                 await refreshSession();
             } catch (error) {
-                if (!isMounted) {
-                    return;
-                }
-
                 if (error.status === 401) {
                     clearSessionRefreshTimestamp();
-                    navigateToLoginPage();
                     return;
                 }
 
-                if (showLoadingState) {
-                    console.error("Failed to refresh the current session.", error);
-                }
-            } finally {
-                if (isMounted) {
-                    setIsSessionReady(true);
-                }
+                console.error("Failed to refresh the current session.", error);
             }
         };
 
-        if (initialDelay > 0) {
-            setIsSessionReady(true);
-        }
+        const initialDelay = getSessionRefreshDelay(REFRESH_INTERVAL_MS);
 
         timeoutId = window.setTimeout(() => {
-            void syncSession(initialDelay === 0);
+            void syncSession();
 
             intervalId = window.setInterval(() => {
-                void syncSession(false);
+                void syncSession();
             }, REFRESH_INTERVAL_MS);
         }, initialDelay);
 
         return () => {
-            isMounted = false;
             window.clearTimeout(timeoutId);
             window.clearInterval(intervalId);
         };
     }, []);
-
-    if (!isSessionReady) {
-        return (
-            <div className="portal-layout min-h-screen font-[Poppins]" data-portal-theme={theme}>
-                <PortalLayoutSkeleton />
-            </div>
-        );
-    }
 
     return (
         <div className="portal-layout min-h-screen font-[Poppins]" data-portal-theme={theme}>

--- a/frontend/src/pages/Callback.jsx
+++ b/frontend/src/pages/Callback.jsx
@@ -6,15 +6,14 @@ export default function Callback() {
     const navigate = useNavigate();
     const [searchParams] = useSearchParams();
     const [errorMessage, setErrorMessage] = useState("");
+    const identityProviderError = searchParams.get("error");
+    const identityProviderMessage = searchParams.get("error_description");
+    const code = searchParams.get("code");
 
     useEffect(() => {
         let isMounted = true;
 
         const finishAuthorization = async () => {
-            const identityProviderError = searchParams.get("error");
-            const identityProviderMessage = searchParams.get("error_description");
-            const code = searchParams.get("code");
-
             if (identityProviderError) {
                 if (isMounted) {
                     setErrorMessage(identityProviderMessage || identityProviderError);
@@ -49,7 +48,7 @@ export default function Callback() {
         return () => {
             isMounted = false;
         };
-    }, [navigate, searchParams]);
+    }, [code, identityProviderError, identityProviderMessage, navigate]);
 
     return (
         <div className="relative min-h-screen overflow-hidden bg-[#250508] font-[Poppins] text-white">

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -4,7 +4,7 @@ import PortalHero from "../components/dashboard/PortalHero";
 import PortalToolbar from "../components/dashboard/PortalToolbar";
 import SystemGrid from "../components/dashboard/SystemGrid";
 import Pagination from "../components/Pagination";
-import { startAuthorization } from "../services/auth";
+import { navigateToLoginPage } from "../services/auth";
 import { getUserAccessSystems } from "../services/userAccess";
 
 const CARDS_PER_PAGE = 6;
@@ -40,8 +40,7 @@ export default function OnePortalHome() {
     const [isLoadingSystems, setIsLoadingSystems] = useState(true);
     const [systemsError, setSystemsError] = useState("");
     const [systemsErrorStatus, setSystemsErrorStatus] = useState(null);
-    const [isStartingAuthorization, setIsStartingAuthorization] = useState(false);
-    const [authorizationError, setAuthorizationError] = useState("");
+    const [isRedirectingToLogin, setIsRedirectingToLogin] = useState(false);
 
     useEffect(() => {
         setCurrentPage(1);
@@ -105,17 +104,9 @@ export default function OnePortalHome() {
         }
     }, [currentPage, totalPages]);
 
-    const handleSignIn = async () => {
-        setIsStartingAuthorization(true);
-        setAuthorizationError("");
-
-        try {
-            await startAuthorization();
-        } catch (error) {
-            setAuthorizationError(error.message);
-        } finally {
-            setIsStartingAuthorization(false);
-        }
+    const handleSignIn = () => {
+        setIsRedirectingToLogin(true);
+        navigateToLoginPage();
     };
 
     return (
@@ -124,12 +115,12 @@ export default function OnePortalHome() {
                 <PortalHero>
                     {showSignInButton ? (
                         <div className="header-actions">
-                            <button type="button" className="header-action-button" onClick={handleSignIn} disabled={isStartingAuthorization}>
-                                {isStartingAuthorization ? "Redirecting..." : "Sign in to continue"}
+                            <button type="button" className="header-action-button" onClick={handleSignIn} disabled={isRedirectingToLogin}>
+                                {isRedirectingToLogin ? "Opening login..." : "Login with IDP"}
                             </button>
 
-                            <p className={`header-note ${authorizationError ? "header-note--error" : ""}`}>
-                                {authorizationError || "Access is personalized. Sign in to load your available systems."}
+                            <p className="header-note">
+                                Access is personalized. Continue through the IDP login page to load your available systems.
                             </p>
                         </div>
                     ) : null}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -4,18 +4,14 @@ import PortalHero from "../components/dashboard/PortalHero";
 import PortalToolbar from "../components/dashboard/PortalToolbar";
 import SystemGrid from "../components/dashboard/SystemGrid";
 import Pagination from "../components/Pagination";
-import { navigateToLoginPage } from "../services/auth";
+import { clearSessionState, navigateToLandingPage } from "../services/auth";
 import { getUserAccessSystems } from "../services/userAccess";
 
 const CARDS_PER_PAGE = 6;
 
-function getEmptyStateMessage({ isLoadingSystems, systemsError, systemsErrorStatus, searchQuery, hasSystems }) {
+function getEmptyStateMessage({ isLoadingSystems, systemsError, searchQuery, hasSystems }) {
     if (isLoadingSystems) {
         return "Loading your available systems...";
-    }
-
-    if (systemsErrorStatus === 401) {
-        return "Sign in to view the systems available to your account.";
     }
 
     if (systemsError) {
@@ -40,7 +36,6 @@ export default function OnePortalHome() {
     const [isLoadingSystems, setIsLoadingSystems] = useState(true);
     const [systemsError, setSystemsError] = useState("");
     const [systemsErrorStatus, setSystemsErrorStatus] = useState(null);
-    const [isRedirectingToLogin, setIsRedirectingToLogin] = useState(false);
 
     useEffect(() => {
         setCurrentPage(1);
@@ -84,16 +79,23 @@ export default function OnePortalHome() {
         };
     }, []);
 
+    useEffect(() => {
+        if (systemsErrorStatus !== 401) {
+            return;
+        }
+
+        clearSessionState();
+        navigateToLandingPage();
+    }, [systemsErrorStatus]);
+
     const normalizedQuery = searchQuery.toLowerCase();
     const filteredSystems = availableSystems.filter((system) =>
         system.title.toLowerCase().includes(normalizedQuery)
     );
     const totalPages = Math.max(1, Math.ceil(filteredSystems.length / CARDS_PER_PAGE));
-    const showSignInButton = systemsErrorStatus === 401;
     const emptyStateMessage = getEmptyStateMessage({
         isLoadingSystems,
         systemsError,
-        systemsErrorStatus,
         searchQuery,
         hasSystems: availableSystems.length > 0,
     });
@@ -104,33 +106,20 @@ export default function OnePortalHome() {
         }
     }, [currentPage, totalPages]);
 
-    const handleSignIn = () => {
-        setIsRedirectingToLogin(true);
-        navigateToLoginPage();
-    };
+    if (systemsErrorStatus === 401) {
+        return null;
+    }
 
     return (
         <OnePortalLayout>
             <div className="portal-home">
-                <PortalHero>
-                    {showSignInButton ? (
-                        <div className="header-actions">
-                            <button type="button" className="header-action-button" onClick={handleSignIn} disabled={isRedirectingToLogin}>
-                                {isRedirectingToLogin ? "Opening login..." : "Login with IDP"}
-                            </button>
-
-                            <p className="header-note">
-                                Access is personalized. Continue through the IDP login page to load your available systems.
-                            </p>
-                        </div>
-                    ) : null}
-                </PortalHero>
+                <PortalHero />
                 <main className="portal-home__main">
                     <div className="portal-home__shell">
                         <PortalToolbar
                             searchQuery={searchQuery}
                             setSearchQuery={setSearchQuery}
-                            isSearchDisabled={isLoadingSystems || showSignInButton || Boolean(systemsError)}
+                            isSearchDisabled={isLoadingSystems || Boolean(systemsError)}
                         />
 
                         <SystemGrid

--- a/frontend/src/pages/Landing.jsx
+++ b/frontend/src/pages/Landing.jsx
@@ -2,13 +2,31 @@ import { useState } from "react";
 import { navigateToLoginPage } from "../services/auth";
 import "../styles/AuthEntry.css";
 
-const ACCESS_GROUPS = ["Students", "Faculty", "Staff"];
+function LoginIcon() {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+            <path
+                fillRule="evenodd"
+                d="M16.5 3.75a1.5 1.5 0 0 1 1.5 1.5v13.5a1.5 1.5 0 0 1-1.5 1.5h-6a1.5 1.5 0 0 1-1.5-1.5V15a.75.75 0 0 0-1.5 0v3.75a3 3 0 0 0 3 3h6a3 3 0 0 0 3-3V5.25a3 3 0 0 0-3-3h-6a3 3 0 0 0-3 3V9A.75.75 0 1 0 9 9V5.25a1.5 1.5 0 0 1 1.5-1.5h6Zm-5.03 4.72a.75.75 0 0 0 0 1.06l1.72 1.72H2.25a.75.75 0 0 0 0 1.5h10.94l-1.72 1.72a.75.75 0 1 0 1.06 1.06l3-3a.75.75 0 0 0 0-1.06l-3-3a.75.75 0 0 0-1.06 0Z"
+                clipRule="evenodd"
+            />
+        </svg>
+    );
+}
+
+function RegisterIcon() {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M5.25 6.375a4.125 4.125 0 1 1 8.25 0 4.125 4.125 0 0 1-8.25 0ZM2.25 19.125a7.125 7.125 0 0 1 14.25 0v.003l-.001.119a.75.75 0 0 1-.363.63 13.067 13.067 0 0 1-6.761 1.873c-2.472 0-4.786-.684-6.76-1.873a.75.75 0 0 1-.364-.63l-.001-.122ZM18.75 7.5a.75.75 0 0 0-1.5 0v2.25H15a.75.75 0 0 0 0 1.5h2.25v2.25a.75.75 0 0 0 1.5 0v-2.25H21a.75.75 0 0 0 0-1.5h-2.25V7.5Z" />
+        </svg>
+    );
+}
 
 export default function Landing() {
-    const [isRedirectingToLogin, setIsRedirectingToLogin] = useState(false);
+    const [pendingAction, setPendingAction] = useState("");
 
-    const handleLogin = () => {
-        setIsRedirectingToLogin(true);
+    const handlePortalEntry = (action) => {
+        setPendingAction(action);
         navigateToLoginPage();
     };
 
@@ -21,47 +39,63 @@ export default function Landing() {
 
             <div className="auth-entry__shell">
                 <header className="auth-entry__brand">
-                    <img src="/assets/images/PUPlogo.png" alt="PUP Taguig seal" className="auth-entry__logo float-logo" />
+                    <img src="/assets/images/PUPlogo.png" alt="PUP Taguig seal" className="auth-entry__logo" />
 
                     <div className="auth-entry__brand-copy">
                         <p className="auth-entry__brand-name">PUP Taguig One Portal</p>
-                        <p className="auth-entry__brand-line">A simpler entry point for campus systems.</p>
+                        <p className="auth-entry__brand-line">POLYTECHNIC UNIVERSITY OF THE PHILIPPINES - TAGUIG CAMPUS</p>
                     </div>
                 </header>
 
                 <main className="auth-entry__hero">
                     <section className="auth-entry__content">
                         <p className="auth-entry__eyebrow">One Portal</p>
-                        <h1 className="auth-entry__title">Start in one place.</h1>
+                        <h1 className="auth-entry__title">
+                            Access your PUP Taguig
+                            <span className="auth-entry__title-accent"> systems in one portal.</span>
+                        </h1>
                         <p className="auth-entry__description">
-                            Clean, focused access to the systems you need.
+                            Open academic, administrative, and campus services from a single secure starting point.
                         </p>
-
-                        <div className="auth-entry__actions">
-                            <button
-                                type="button"
-                                className="auth-entry__button"
-                                onClick={handleLogin}
-                                disabled={isRedirectingToLogin}
-                            >
-                                {isRedirectingToLogin ? "Opening login..." : "Login with IDP"}
-                            </button>
-                        </div>
                     </section>
 
-                    <aside className="auth-entry__panel" aria-hidden="true">
-                        <div className="auth-entry__chips">
-                            {ACCESS_GROUPS.map((group) => (
-                                <span key={group} className="auth-entry__chip">
-                                    {group}
-                                </span>
-                            ))}
+                    <aside className="auth-entry__portal-card">
+                        <div className="auth-entry__portal-mark">
+                            <img src="/assets/images/PUPlogo.png" alt="" className="auth-entry__portal-logo" />
                         </div>
 
-                        <div className="auth-entry__panel-card">
-                            <p className="auth-entry__panel-label">Secure access</p>
-                            <p className="auth-entry__panel-copy">Move from the landing page to the IDP login and into One Portal.</p>
+                        <h2 className="auth-entry__portal-title">Portal Access</h2>
+                        <p className="auth-entry__portal-copy">
+                            Continue with your campus identity to reach the systems available to your account.
+                        </p>
+
+                        <div className="auth-entry__portal-actions">
+                            <button
+                                type="button"
+                                className="auth-entry__portal-button"
+                                onClick={() => handlePortalEntry("login")}
+                                disabled={Boolean(pendingAction)}
+                            >
+                                <span className="auth-entry__portal-button-icon" aria-hidden="true">
+                                    <LoginIcon />
+                                </span>
+                                <span>{pendingAction === "login" ? "Opening..." : "Login"}</span>
+                            </button>
+
+                            <button
+                                type="button"
+                                className="auth-entry__portal-button auth-entry__portal-button--secondary"
+                                onClick={() => handlePortalEntry("register")}
+                                disabled={Boolean(pendingAction)}
+                            >
+                                <span className="auth-entry__portal-button-icon" aria-hidden="true">
+                                    <RegisterIcon />
+                                </span>
+                                <span>{pendingAction === "register" ? "Opening..." : "Register"}</span>
+                            </button>
                         </div>
+
+                        <p className="auth-entry__portal-note">Use the campus identity page to continue into One Portal.</p>
                     </aside>
                 </main>
             </div>

--- a/frontend/src/pages/Landing.jsx
+++ b/frontend/src/pages/Landing.jsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import { navigateToLoginPage } from "../services/auth";
+import "../styles/AuthEntry.css";
+
+const ACCESS_GROUPS = ["Students", "Faculty", "Staff"];
+
+export default function Landing() {
+    const [isRedirectingToLogin, setIsRedirectingToLogin] = useState(false);
+
+    const handleLogin = () => {
+        setIsRedirectingToLogin(true);
+        navigateToLoginPage();
+    };
+
+    return (
+        <div className="auth-entry auth-entry--landing">
+            <div className="auth-entry__background" aria-hidden="true">
+                <img src="/assets/images/pup_bg.png" alt="" className="auth-entry__background-image" />
+                <div className="auth-entry__background-overlay" />
+            </div>
+
+            <div className="auth-entry__shell">
+                <header className="auth-entry__brand">
+                    <img src="/assets/images/PUPlogo.png" alt="PUP Taguig seal" className="auth-entry__logo float-logo" />
+
+                    <div className="auth-entry__brand-copy">
+                        <p className="auth-entry__brand-name">PUP Taguig One Portal</p>
+                        <p className="auth-entry__brand-line">A simpler entry point for campus systems.</p>
+                    </div>
+                </header>
+
+                <main className="auth-entry__hero">
+                    <section className="auth-entry__content">
+                        <p className="auth-entry__eyebrow">One Portal</p>
+                        <h1 className="auth-entry__title">Start in one place.</h1>
+                        <p className="auth-entry__description">
+                            Clean, focused access to the systems you need.
+                        </p>
+
+                        <div className="auth-entry__actions">
+                            <button
+                                type="button"
+                                className="auth-entry__button"
+                                onClick={handleLogin}
+                                disabled={isRedirectingToLogin}
+                            >
+                                {isRedirectingToLogin ? "Opening login..." : "Login with IDP"}
+                            </button>
+                        </div>
+                    </section>
+
+                    <aside className="auth-entry__panel" aria-hidden="true">
+                        <div className="auth-entry__chips">
+                            {ACCESS_GROUPS.map((group) => (
+                                <span key={group} className="auth-entry__chip">
+                                    {group}
+                                </span>
+                            ))}
+                        </div>
+
+                        <div className="auth-entry__panel-card">
+                            <p className="auth-entry__panel-label">Secure access</p>
+                            <p className="auth-entry__panel-copy">Move from the landing page to the IDP login and into One Portal.</p>
+                        </div>
+                    </aside>
+                </main>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { startAuthorization } from "../services/auth";
+import "../styles/AuthEntry.css";
+
+export default function Login() {
+    const [isStartingAuthorization, setIsStartingAuthorization] = useState(true);
+    const [errorMessage, setErrorMessage] = useState("");
+
+    const beginAuthorization = async () => {
+        setIsStartingAuthorization(true);
+        setErrorMessage("");
+
+        try {
+            await startAuthorization();
+        } catch (error) {
+            setErrorMessage(error.message || "Unable to continue to the IDP right now.");
+            setIsStartingAuthorization(false);
+        }
+    };
+
+    useEffect(() => {
+        void beginAuthorization();
+    }, []);
+
+    return (
+        <div className="auth-entry auth-entry--login">
+            <div className="auth-entry__background" aria-hidden="true">
+                <img src="/assets/images/pup_bg.png" alt="" className="auth-entry__background-image" />
+                <div className="auth-entry__background-overlay" />
+            </div>
+
+            <div className="auth-entry__shell auth-entry__shell--compact">
+                <header className="auth-entry__brand auth-entry__brand--centered">
+                    <img src="/assets/images/PUPlogo.png" alt="PUP Taguig seal" className="auth-entry__logo float-logo" />
+
+                    <div className="auth-entry__brand-copy">
+                        <p className="auth-entry__brand-name">PUP Taguig One Portal</p>
+                        <p className="auth-entry__brand-line">Preparing your secure sign-in.</p>
+                    </div>
+                </header>
+
+                <main className="auth-entry__login-shell">
+                    <section className="auth-entry__login-card">
+                        <p className="auth-entry__eyebrow">Secure Sign-In</p>
+                        <h1 className="auth-entry__title auth-entry__title--compact">Redirecting to IDP</h1>
+                        <p className="auth-entry__description auth-entry__description--compact">
+                            {errorMessage || "Please wait while we open the login page."}
+                        </p>
+
+                        {errorMessage ? (
+                            <div className="auth-entry__actions auth-entry__actions--stacked">
+                                <button
+                                    type="button"
+                                    className="auth-entry__button"
+                                    onClick={() => void beginAuthorization()}
+                                    disabled={isStartingAuthorization}
+                                >
+                                    {isStartingAuthorization ? "Opening..." : "Login with IDP"}
+                                </button>
+
+                                <Link to="/" className="auth-entry__link">
+                                    Return to landing page
+                                </Link>
+                            </div>
+                        ) : (
+                            <div className="auth-entry__status" aria-live="polite">
+                                <span className="auth-entry__status-dot" />
+                                <span>{isStartingAuthorization ? "Opening your secure login..." : "Redirecting..."}</span>
+                            </div>
+                        )}
+                    </section>
+                </main>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,76 +1,86 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
-import { startAuthorization } from "../services/auth";
-import "../styles/AuthEntry.css";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { completeAuthorization, startAuthorization } from "../services/auth";
 
 export default function Login() {
-    const [isStartingAuthorization, setIsStartingAuthorization] = useState(true);
-    const [errorMessage, setErrorMessage] = useState("");
+    const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
+    const [hasAuthorizationError, setHasAuthorizationError] = useState(false);
 
-    const beginAuthorization = async () => {
-        setIsStartingAuthorization(true);
-        setErrorMessage("");
-
-        try {
-            await startAuthorization();
-        } catch (error) {
-            setErrorMessage(error.message || "Unable to continue to the IDP right now.");
-            setIsStartingAuthorization(false);
-        }
-    };
+    const identityProviderError = searchParams.get("error");
+    const code = searchParams.get("code");
 
     useEffect(() => {
-        void beginAuthorization();
-    }, []);
+        let isMounted = true;
+
+        const handleLoginFlow = async () => {
+            if (identityProviderError) {
+                if (isMounted) {
+                    setHasAuthorizationError(true);
+                }
+
+                return;
+            }
+
+            if (code) {
+                try {
+                    await completeAuthorization(code);
+
+                    if (isMounted) {
+                        navigate("/portal", { replace: true });
+                    }
+                } catch (error) {
+                    if (isMounted) {
+                        setHasAuthorizationError(true);
+                    }
+                }
+
+                return;
+            }
+
+            if (isMounted) {
+                setHasAuthorizationError(false);
+            }
+
+            try {
+                await startAuthorization();
+            } catch (error) {
+                if (isMounted) {
+                    setHasAuthorizationError(true);
+                }
+            }
+        };
+
+        void handleLoginFlow();
+
+        return () => {
+            isMounted = false;
+        };
+    }, [code, identityProviderError, navigate]);
 
     return (
-        <div className="auth-entry auth-entry--login">
-            <div className="auth-entry__background" aria-hidden="true">
-                <img src="/assets/images/pup_bg.png" alt="" className="auth-entry__background-image" />
-                <div className="auth-entry__background-overlay" />
+        <div className="relative min-h-screen overflow-hidden bg-[#250508] font-[Poppins] text-white">
+            <div className="absolute inset-0">
+                <div
+                    className="absolute inset-0 bg-cover bg-center"
+                    style={{ backgroundImage: "url(/assets/images/pup_bg.png)" }}
+                />
+                <div className="absolute inset-0 bg-gradient-to-br from-[#2b0307]/90 via-[#7b0d15]/80 to-[#180204]/90" />
+                <div className="absolute left-[-10rem] top-[-8rem] h-72 w-72 rounded-full bg-[#f8d24e]/20 blur-3xl" />
+                <div className="absolute bottom-[-10rem] right-[-6rem] h-80 w-80 rounded-full bg-white/10 blur-3xl" />
             </div>
 
-            <div className="auth-entry__shell auth-entry__shell--compact">
-                <header className="auth-entry__brand auth-entry__brand--centered">
-                    <img src="/assets/images/PUPlogo.png" alt="PUP Taguig seal" className="auth-entry__logo" />
+            <div className="relative flex min-h-screen flex-col items-center justify-center gap-5 px-4 text-center">
+                <img src="/assets/images/PUPlogo.png" alt="PUP Logo" className="float-logo w-28 sm:w-32" />
 
-                    <div className="auth-entry__brand-copy">
-                        <p className="auth-entry__brand-name">PUP Taguig One Portal</p>
-                        <p className="auth-entry__brand-line">Preparing your secure sign-in.</p>
-                    </div>
-                </header>
-
-                <main className="auth-entry__login-shell">
-                    <section className="auth-entry__login-card">
-                        <p className="auth-entry__eyebrow">Secure Sign-In</p>
-                        <h1 className="auth-entry__title auth-entry__title--compact">Redirecting to IDP</h1>
-                        <p className="auth-entry__description auth-entry__description--compact">
-                            {errorMessage || "Please wait while we open the login page."}
-                        </p>
-
-                        {errorMessage ? (
-                            <div className="auth-entry__actions auth-entry__actions--stacked">
-                                <button
-                                    type="button"
-                                    className="auth-entry__button"
-                                    onClick={() => void beginAuthorization()}
-                                    disabled={isStartingAuthorization}
-                                >
-                                    {isStartingAuthorization ? "Opening..." : "Login with IDP"}
-                                </button>
-
-                                <Link to="/" className="auth-entry__link">
-                                    Return to landing page
-                                </Link>
-                            </div>
-                        ) : (
-                            <div className="auth-entry__status" aria-live="polite">
-                                <span className="auth-entry__status-dot" />
-                                <span>{isStartingAuthorization ? "Opening your secure login..." : "Redirecting..."}</span>
-                            </div>
-                        )}
-                    </section>
-                </main>
+                {hasAuthorizationError && (
+                    <Link
+                        to="/"
+                        className="inline-flex min-h-12 items-center justify-center rounded-full bg-[#f8d24e] px-6 py-3 text-sm font-semibold text-[#5c0b10] shadow-[0_18px_40px_rgba(0,0,0,0.28)] transition hover:-translate-y-0.5 hover:bg-[#ffe27a]"
+                    >
+                        Return to home page
+                    </Link>
+                )}
             </div>
         </div>
     );

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -32,7 +32,7 @@ export default function Login() {
 
             <div className="auth-entry__shell auth-entry__shell--compact">
                 <header className="auth-entry__brand auth-entry__brand--centered">
-                    <img src="/assets/images/PUPlogo.png" alt="PUP Taguig seal" className="auth-entry__logo float-logo" />
+                    <img src="/assets/images/PUPlogo.png" alt="PUP Taguig seal" className="auth-entry__logo" />
 
                     <div className="auth-entry__brand-copy">
                         <p className="auth-entry__brand-name">PUP Taguig One Portal</p>

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import OnePortalLayout from "../layouts/OnePortalLayout";
 import ProfileCard from "../components/profile/ProfileCard";
 import AuditLogs from "../components/profile/AuditLogs";
+import { clearSessionState, navigateToLandingPage } from "../services/auth";
 import { getRecentAuditLogs } from "../services/logs";
 
 export default function Profile() {
@@ -9,6 +10,7 @@ export default function Profile() {
     const [localLogs, setLocalLogs] = useState([]);
     const [isLoadingLogs, setIsLoadingLogs] = useState(true);
     const [logsError, setLogsError] = useState("");
+    const [logsErrorStatus, setLogsErrorStatus] = useState(null);
 
     const profile = {
         firstName: "Juan",
@@ -29,10 +31,12 @@ export default function Profile() {
                 if (isMounted) {
                     setBackendLogs(recentLogs);
                     setLogsError("");
+                    setLogsErrorStatus(null);
                 }
             } catch (error) {
                 if (isMounted) {
                     setLogsError(error.message);
+                    setLogsErrorStatus(error.status ?? null);
                 }
             } finally {
                 if (isMounted) {
@@ -48,11 +52,24 @@ export default function Profile() {
         };
     }, []);
 
+    useEffect(() => {
+        if (logsErrorStatus !== 401) {
+            return;
+        }
+
+        clearSessionState();
+        navigateToLandingPage();
+    }, [logsErrorStatus]);
+
     const handleAddAuditLog = (log) => {
         setLocalLogs((currentLogs) => [log, ...currentLogs]);
     };
 
     const logs = [...localLogs, ...backendLogs];
+
+    if (logsErrorStatus === 401) {
+        return null;
+    }
 
     return (
         <OnePortalLayout>

--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -2,7 +2,9 @@ import { apiRequest, fetchApiResponse, getApiUrl, readApiResponse } from "./api"
 
 const SESSION_REFRESH_TIMESTAMP_KEY = "one-portal:last-session-refresh-at";
 const AUTHORIZATION_PATH = "/auth/authorize";
+const LANDING_ROUTE_PATH = "/landingRoute";
 let authorizationRequestPromise = null;
+let authorizationCompletionPromise = null;
 
 function hasLocalStorage() {
     return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
@@ -70,7 +72,7 @@ export function getLoginPageUrl() {
 }
 
 export function getLandingPageUrl() {
-    return getAppUrl("/");
+    return getAppUrl(LANDING_ROUTE_PATH);
 }
 
 export function getLogoutFallbackUrl() {
@@ -183,14 +185,24 @@ export async function startAuthorization() {
 }
 
 export async function completeAuthorization(code) {
-    const data = await apiRequest("/auth/callback", {
-        method: "POST",
-        data: { code },
-    });
+    if (!authorizationCompletionPromise) {
+        authorizationCompletionPromise = (async () => {
+            const data = await apiRequest("/auth/callback", {
+                method: "POST",
+                data: { code },
+            });
 
-    writeSessionRefreshTimestamp();
+            writeSessionRefreshTimestamp();
 
-    return data;
+            return data;
+        })();
+    }
+
+    try {
+        return await authorizationCompletionPromise;
+    } finally {
+        authorizationCompletionPromise = null;
+    }
 }
 
 export async function logoutSession() {

--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -1,6 +1,7 @@
-import { apiRequest } from "./api";
+import { apiRequest, fetchApiResponse, getApiUrl, readApiResponse } from "./api";
 
 const SESSION_REFRESH_TIMESTAMP_KEY = "one-portal:last-session-refresh-at";
+const AUTHORIZATION_PATH = "/auth/authorize";
 
 function hasLocalStorage() {
     return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
@@ -67,9 +68,75 @@ export function getLogoutFallbackUrl() {
     return getLoginPageUrl();
 }
 
+function getAuthorizationResponseUrl(data) {
+    if (!data || typeof data === "string") {
+        return "";
+    }
+
+    const authorizationUrl = data.redirect_url ?? data.redirectUrl ?? data.url;
+
+    return typeof authorizationUrl === "string" ? authorizationUrl.trim() : "";
+}
+
+function getAuthorizationLocationUrl(response) {
+    const location = response.headers.get("location");
+
+    if (!location) {
+        return "";
+    }
+
+    try {
+        return new URL(location, getApiUrl(AUTHORIZATION_PATH)).toString();
+    } catch (error) {
+        console.error("Invalid authorization redirect URL.", error);
+        return "";
+    }
+}
+
+function createAuthorizationError(status, data) {
+    const message = typeof data === "string" && data.trim()
+        ? data
+        : data?.error ?? data?.message ?? `Request failed with status ${status}`;
+    const error = new Error(message);
+
+    error.status = status;
+    error.data = data;
+
+    return error;
+}
+
+async function getAuthorizationUrl() {
+    const response = await fetchApiResponse(AUTHORIZATION_PATH, {
+        method: "GET",
+        redirect: "manual",
+    });
+    const locationUrl = getAuthorizationLocationUrl(response);
+
+    if (locationUrl) {
+        return locationUrl;
+    }
+
+    const data = await readApiResponse(response);
+
+    if (!response.ok) {
+        throw createAuthorizationError(response.status, data);
+    }
+
+    return getAuthorizationResponseUrl(data) || getLoginPageUrl();
+}
+
 export async function startAuthorization() {
-    window.location.assign(getLoginPageUrl());
-    return true;
+    try {
+        const authorizationUrl = await getAuthorizationUrl();
+
+        window.location.assign(authorizationUrl);
+        return true;
+    } catch (error) {
+        console.error("Failed to start authorization through /auth/authorize. Falling back to the login page.", error);
+
+        window.location.assign(getLoginPageUrl());
+        return false;
+    }
 }
 
 export async function completeAuthorization(code) {

--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -2,6 +2,7 @@ import { apiRequest, fetchApiResponse, getApiUrl, readApiResponse } from "./api"
 
 const SESSION_REFRESH_TIMESTAMP_KEY = "one-portal:last-session-refresh-at";
 const AUTHORIZATION_PATH = "/auth/authorize";
+let authorizationRequestPromise = null;
 
 function hasLocalStorage() {
     return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
@@ -27,6 +28,10 @@ function writeSessionRefreshTimestamp(timestamp = Date.now()) {
     }
 
     window.localStorage.setItem(SESSION_REFRESH_TIMESTAMP_KEY, String(timestamp));
+}
+
+function getAppUrl(pathname) {
+    return new URL(pathname, window.location.origin).toString();
 }
 
 function getConfiguredLoginPageUrl() {
@@ -64,8 +69,28 @@ export function getLoginPageUrl() {
     return loginUrl.toString();
 }
 
+export function getLandingPageUrl() {
+    return getAppUrl("/");
+}
+
 export function getLogoutFallbackUrl() {
-    return getLoginPageUrl();
+    return getLandingPageUrl();
+}
+
+function isCurrentPage(url) {
+    return window.location.href === url;
+}
+
+export function navigateToLoginPage() {
+    const loginPageUrl = getLoginPageUrl();
+
+    if (isCurrentPage(loginPageUrl)) {
+        return false;
+    }
+
+    window.location.assign(loginPageUrl);
+
+    return true;
 }
 
 function getAuthorizationResponseUrl(data) {
@@ -105,6 +130,14 @@ function createAuthorizationError(status, data) {
     return error;
 }
 
+function createMissingAuthorizationRedirectError() {
+    const error = new Error("The authorization redirect is unavailable.");
+
+    error.status = 500;
+
+    return error;
+}
+
 async function getAuthorizationUrl() {
     const response = await fetchApiResponse(AUTHORIZATION_PATH, {
         method: "GET",
@@ -122,20 +155,30 @@ async function getAuthorizationUrl() {
         throw createAuthorizationError(response.status, data);
     }
 
-    return getAuthorizationResponseUrl(data) || getLoginPageUrl();
+    const authorizationUrl = getAuthorizationResponseUrl(data);
+
+    if (authorizationUrl) {
+        return authorizationUrl;
+    }
+
+    throw createMissingAuthorizationRedirectError();
 }
 
 export async function startAuthorization() {
+    if (!authorizationRequestPromise) {
+        authorizationRequestPromise = (async () => {
+            const authorizationUrl = await getAuthorizationUrl();
+
+            window.location.assign(authorizationUrl);
+
+            return true;
+        })();
+    }
+
     try {
-        const authorizationUrl = await getAuthorizationUrl();
-
-        window.location.assign(authorizationUrl);
-        return true;
-    } catch (error) {
-        console.error("Failed to start authorization through /auth/authorize. Falling back to the login page.", error);
-
-        window.location.assign(getLoginPageUrl());
-        return false;
+        return await authorizationRequestPromise;
+    } finally {
+        authorizationRequestPromise = null;
     }
 }
 

--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -3,11 +3,16 @@ import { apiRequest, fetchApiResponse, getApiUrl, readApiResponse } from "./api"
 const SESSION_REFRESH_TIMESTAMP_KEY = "one-portal:last-session-refresh-at";
 const AUTHORIZATION_PATH = "/auth/authorize";
 const LANDING_ROUTE_PATH = "/landingRoute";
+const SESSION_COOKIE_NAMES = ["access_token", "session_cookie"];
 let authorizationRequestPromise = null;
 let authorizationCompletionPromise = null;
 
 function hasLocalStorage() {
     return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+function hasDocument() {
+    return typeof document !== "undefined";
 }
 
 function readSessionRefreshTimestamp() {
@@ -83,6 +88,18 @@ function isCurrentPage(url) {
     return window.location.href === url;
 }
 
+export function navigateToLandingPage() {
+    const landingPageUrl = getLandingPageUrl();
+
+    if (isCurrentPage(landingPageUrl)) {
+        return false;
+    }
+
+    window.location.assign(landingPageUrl);
+
+    return true;
+}
+
 export function navigateToLoginPage() {
     const loginPageUrl = getLoginPageUrl();
 
@@ -103,6 +120,14 @@ function getAuthorizationResponseUrl(data) {
     const authorizationUrl = data.redirect_url ?? data.redirectUrl ?? data.url;
 
     return typeof authorizationUrl === "string" ? authorizationUrl.trim() : "";
+}
+
+function getLogoutResponseUrl(data) {
+    if (!data || typeof data === "string") {
+        return "";
+    }
+
+    return typeof data.url === "string" ? data.url.trim() : "";
 }
 
 function getAuthorizationLocationUrl(response) {
@@ -205,10 +230,67 @@ export async function completeAuthorization(code) {
     }
 }
 
-export async function logoutSession() {
-    await apiRequest("/auth/logout", {
-        method: "POST",
+export function clearSessionCookies() {
+    if (!hasDocument()) {
+        return;
+    }
+
+    SESSION_COOKIE_NAMES.forEach((cookieName) => {
+        document.cookie = `${cookieName}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
     });
+}
+
+async function notifyBrowserLogout(logoutUrl) {
+    if (!logoutUrl || !hasDocument() || !document.body) {
+        return;
+    }
+
+    await new Promise((resolve) => {
+        const logoutFrame = document.createElement("iframe");
+        const cleanup = () => {
+            window.clearTimeout(timeoutId);
+
+            if (logoutFrame.parentNode) {
+                logoutFrame.parentNode.removeChild(logoutFrame);
+            }
+        };
+        const finish = () => {
+            cleanup();
+            resolve();
+        };
+        const timeoutId = window.setTimeout(finish, 2000);
+
+        logoutFrame.style.display = "none";
+        logoutFrame.setAttribute("aria-hidden", "true");
+        logoutFrame.onload = finish;
+        logoutFrame.onerror = finish;
+        logoutFrame.src = logoutUrl;
+
+        document.body.appendChild(logoutFrame);
+    });
+}
+
+export function clearSessionState() {
+    authorizationRequestPromise = null;
+    authorizationCompletionPromise = null;
+    clearSessionRefreshTimestamp();
+    clearSessionCookies();
+}
+
+export async function logoutSession() {
+    let logoutUrl = "";
+
+    try {
+        const data = await apiRequest("/auth/logout", {
+            method: "POST",
+        });
+
+        logoutUrl = getLogoutResponseUrl(data);
+    } finally {
+        clearSessionState();
+    }
+
+    await notifyBrowserLogout(logoutUrl);
 
     return getLogoutFallbackUrl();
 }

--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -138,11 +138,7 @@ function createMissingAuthorizationRedirectError() {
     return error;
 }
 
-async function getAuthorizationUrl() {
-    const response = await fetchApiResponse(AUTHORIZATION_PATH, {
-        method: "GET",
-        redirect: "manual",
-    });
+async function readAuthorizationUrl(response) {
     const locationUrl = getAuthorizationLocationUrl(response);
 
     if (locationUrl) {
@@ -167,9 +163,13 @@ async function getAuthorizationUrl() {
 export async function startAuthorization() {
     if (!authorizationRequestPromise) {
         authorizationRequestPromise = (async () => {
-            const authorizationUrl = await getAuthorizationUrl();
+            const response = await fetchApiResponse(AUTHORIZATION_PATH, {
+                method: "GET",
+                redirect: "manual",
+            });
+            const authorizationUrl = await readAuthorizationUrl(response);
 
-            window.location.assign(authorizationUrl);
+            window.location.href = authorizationUrl;
 
             return true;
         })();

--- a/frontend/src/styles/AuthEntry.css
+++ b/frontend/src/styles/AuthEntry.css
@@ -1,9 +1,17 @@
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap");
+
 .auth-entry {
     position: relative;
     min-height: 100vh;
     overflow: hidden;
     color: #fff7ed;
     background: #240406;
+    font-family: "Poppins", sans-serif;
+}
+
+.auth-entry button,
+.auth-entry a {
+    font-family: inherit;
 }
 
 .auth-entry::before,
@@ -99,7 +107,9 @@
 .auth-entry__brand-line {
     margin: 0;
     color: rgba(255, 247, 237, 0.78);
-    font-size: 0.95rem;
+    font-size: 0.92rem;
+    font-weight: 500;
+    letter-spacing: 0.02em;
     line-height: 1.5;
 }
 
@@ -133,6 +143,11 @@
     text-shadow: 0 18px 40px rgba(0, 0, 0, 0.26);
 }
 
+.auth-entry__title-accent {
+    display: block;
+    color: #f8d24e;
+}
+
 .auth-entry__title--compact {
     font-size: clamp(2rem, 5vw, 3.2rem);
     line-height: 1.02;
@@ -142,8 +157,8 @@
     max-width: 28rem;
     margin: 1.2rem 0 0;
     color: rgba(255, 247, 237, 0.84);
-    font-size: 1rem;
-    line-height: 1.8;
+    font-size: 1.02rem;
+    line-height: 1.9;
 }
 
 .auth-entry__description--compact {
@@ -196,21 +211,21 @@
     opacity: 0.74;
 }
 
-.auth-entry__panel,
+.auth-entry__portal-card,
 .auth-entry__login-card {
     position: relative;
     overflow: hidden;
-    padding: clamp(1.5rem, 4vw, 2rem);
+    padding: clamp(1.8rem, 4vw, 2.4rem);
     border: 1px solid rgba(255, 255, 255, 0.16);
     border-radius: 2rem;
-    background: linear-gradient(180deg, rgba(31, 41, 55, 0.34), rgba(127, 29, 29, 0.2));
+    background: linear-gradient(180deg, rgba(137, 47, 47, 0.38), rgba(72, 24, 30, 0.46));
     box-shadow:
         0 24px 60px rgba(0, 0, 0, 0.26),
         inset 1px 1px 0 rgba(255, 255, 255, 0.08);
     backdrop-filter: blur(14px);
 }
 
-.auth-entry__panel::before,
+.auth-entry__portal-card::before,
 .auth-entry__login-card::before {
     content: "";
     position: absolute;
@@ -219,43 +234,100 @@
     pointer-events: none;
 }
 
-.auth-entry__chips {
+.auth-entry__portal-card {
+    width: min(100%, 31rem);
+    text-align: center;
+}
+
+.auth-entry__portal-mark {
     display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem;
+    justify-content: center;
+    margin-bottom: 1.35rem;
 }
 
-.auth-entry__chip {
-    padding: 0.55rem 0.85rem;
-    border: 1px solid rgba(255, 255, 255, 0.16);
-    border-radius: 9999px;
-    background: rgba(255, 255, 255, 0.08);
-    color: rgba(255, 247, 237, 0.9);
-    font-size: 0.88rem;
-    font-weight: 600;
+.auth-entry__portal-logo {
+    width: clamp(4.5rem, 10vw, 5.8rem);
+    height: auto;
+    object-fit: contain;
 }
 
-.auth-entry__panel-card {
-    margin-top: 1.35rem;
-    padding: 1.1rem 1rem;
-    border-radius: 1.4rem;
-    background: rgba(255, 255, 255, 0.06);
-}
-
-.auth-entry__panel-label {
+.auth-entry__portal-title {
     margin: 0;
-    color: #fde68a;
-    font-size: 0.8rem;
+    color: #fff7ed;
+    font-size: clamp(1.8rem, 4vw, 2.35rem);
     font-weight: 700;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
+    line-height: 1.1;
 }
 
-.auth-entry__panel-copy {
-    margin: 0.7rem 0 0;
+.auth-entry__portal-copy {
+    max-width: 24rem;
+    margin: 1rem auto 0;
     color: rgba(255, 247, 237, 0.82);
-    font-size: 0.96rem;
-    line-height: 1.7;
+    font-size: 1rem;
+    line-height: 1.75;
+}
+
+.auth-entry__portal-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-top: 2rem;
+}
+
+.auth-entry__portal-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.8rem;
+    width: 100%;
+    min-height: 4rem;
+    padding: 0.9rem 1.4rem;
+    border: 1px solid rgba(255, 255, 255, 0.24);
+    border-radius: 1.2rem;
+    background: rgba(255, 255, 255, 0.14);
+    color: #fff7ed;
+    font-size: 1.02rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    cursor: pointer;
+    transition: transform 0.25s ease, border-color 0.25s ease, background 0.25s ease, box-shadow 0.25s ease, opacity 0.25s ease;
+}
+
+.auth-entry__portal-button:hover:not(:disabled) {
+    transform: translateY(-2px);
+    border-color: rgba(248, 210, 78, 0.46);
+    background: rgba(255, 255, 255, 0.2);
+    box-shadow: 0 14px 32px rgba(0, 0, 0, 0.18);
+}
+
+.auth-entry__portal-button:disabled {
+    cursor: wait;
+    opacity: 0.7;
+}
+
+.auth-entry__portal-button--secondary {
+    background: rgba(255, 255, 255, 0.09);
+}
+
+.auth-entry__portal-button-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.4rem;
+    height: 1.4rem;
+    flex-shrink: 0;
+}
+
+.auth-entry__portal-button-icon svg {
+    width: 100%;
+    height: 100%;
+}
+
+.auth-entry__portal-note {
+    margin: 1.5rem 0 0;
+    color: rgba(255, 247, 237, 0.66);
+    font-size: 0.95rem;
+    line-height: 1.6;
 }
 
 .auth-entry__login-shell {
@@ -325,8 +397,8 @@
         padding-top: 2rem;
     }
 
-    .auth-entry__panel {
-        width: min(100%, 28rem);
+    .auth-entry__portal-card {
+        width: min(100%, 32rem);
     }
 
     .auth-entry__login-shell {
@@ -368,7 +440,7 @@
         width: 100%;
     }
 
-    .auth-entry__panel,
+    .auth-entry__portal-card,
     .auth-entry__login-card {
         width: 100%;
         border-radius: 1.5rem;

--- a/frontend/src/styles/AuthEntry.css
+++ b/frontend/src/styles/AuthEntry.css
@@ -1,0 +1,384 @@
+.auth-entry {
+    position: relative;
+    min-height: 100vh;
+    overflow: hidden;
+    color: #fff7ed;
+    background: #240406;
+}
+
+.auth-entry::before,
+.auth-entry::after {
+    content: "";
+    position: absolute;
+    border-radius: 9999px;
+    filter: blur(18px);
+    pointer-events: none;
+    z-index: 0;
+}
+
+.auth-entry::before {
+    top: -5rem;
+    left: -4rem;
+    width: 18rem;
+    height: 18rem;
+    background: rgba(248, 210, 78, 0.18);
+}
+
+.auth-entry::after {
+    right: -6rem;
+    bottom: -6rem;
+    width: 24rem;
+    height: 24rem;
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.auth-entry__background {
+    position: absolute;
+    inset: 0;
+}
+
+.auth-entry__background-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: brightness(0.42) saturate(1.05);
+}
+
+.auth-entry__background-overlay {
+    position: absolute;
+    inset: 0;
+    background:
+        linear-gradient(135deg, rgba(36, 4, 6, 0.84) 0%, rgba(127, 29, 29, 0.76) 48%, rgba(17, 24, 39, 0.78) 100%),
+        radial-gradient(circle at top, rgba(248, 210, 78, 0.18) 0%, transparent 28%);
+}
+
+.auth-entry__shell {
+    position: relative;
+    z-index: 1;
+    width: min(100%, 1180px);
+    margin: 0 auto;
+    padding: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.auth-entry__shell--compact {
+    width: min(100%, 760px);
+}
+
+.auth-entry__brand {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.auth-entry__brand--centered {
+    justify-content: center;
+    text-align: center;
+}
+
+.auth-entry__logo {
+    width: clamp(4rem, 8vw, 5.5rem);
+    height: auto;
+    object-fit: contain;
+    flex-shrink: 0;
+}
+
+.auth-entry__brand-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.auth-entry__brand-name {
+    margin: 0;
+    font-size: clamp(1.05rem, 2vw, 1.3rem);
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.auth-entry__brand-line {
+    margin: 0;
+    color: rgba(255, 247, 237, 0.78);
+    font-size: 0.95rem;
+    line-height: 1.5;
+}
+
+.auth-entry__hero {
+    display: grid;
+    grid-template-columns: minmax(0, 1.2fr) minmax(18rem, 24rem);
+    align-items: center;
+    gap: clamp(1.5rem, 4vw, 3rem);
+    min-height: calc(100vh - 9rem);
+}
+
+.auth-entry__content {
+    max-width: 34rem;
+}
+
+.auth-entry__eyebrow {
+    margin: 0 0 1rem;
+    color: #fde68a;
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+}
+
+.auth-entry__title {
+    margin: 0;
+    font-size: clamp(2.8rem, 7vw, 5.2rem);
+    font-weight: 800;
+    line-height: 0.95;
+    text-wrap: balance;
+    text-shadow: 0 18px 40px rgba(0, 0, 0, 0.26);
+}
+
+.auth-entry__title--compact {
+    font-size: clamp(2rem, 5vw, 3.2rem);
+    line-height: 1.02;
+}
+
+.auth-entry__description {
+    max-width: 28rem;
+    margin: 1.2rem 0 0;
+    color: rgba(255, 247, 237, 0.84);
+    font-size: 1rem;
+    line-height: 1.8;
+}
+
+.auth-entry__description--compact {
+    max-width: none;
+    margin-top: 1rem;
+}
+
+.auth-entry__actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-top: 2rem;
+}
+
+.auth-entry__actions--stacked {
+    flex-direction: column;
+    align-items: stretch;
+}
+
+.auth-entry__button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 13.5rem;
+    min-height: 3.4rem;
+    padding: 0.85rem 1.6rem;
+    border: 0;
+    border-radius: 9999px;
+    background: linear-gradient(145deg, #f8d24e, #f59e0b);
+    box-shadow:
+        0 16px 34px rgba(0, 0, 0, 0.22),
+        inset 1px 1px 0 rgba(255, 255, 255, 0.28);
+    color: #6b1115;
+    font-size: 0.98rem;
+    font-weight: 800;
+    letter-spacing: 0.02em;
+    cursor: pointer;
+    transition: transform 0.25s ease, box-shadow 0.25s ease, opacity 0.25s ease;
+}
+
+.auth-entry__button:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow:
+        0 18px 38px rgba(0, 0, 0, 0.24),
+        inset 1px 1px 0 rgba(255, 255, 255, 0.3);
+}
+
+.auth-entry__button:disabled {
+    cursor: wait;
+    opacity: 0.74;
+}
+
+.auth-entry__panel,
+.auth-entry__login-card {
+    position: relative;
+    overflow: hidden;
+    padding: clamp(1.5rem, 4vw, 2rem);
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    border-radius: 2rem;
+    background: linear-gradient(180deg, rgba(31, 41, 55, 0.34), rgba(127, 29, 29, 0.2));
+    box-shadow:
+        0 24px 60px rgba(0, 0, 0, 0.26),
+        inset 1px 1px 0 rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(14px);
+}
+
+.auth-entry__panel::before,
+.auth-entry__login-card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent 42%);
+    pointer-events: none;
+}
+
+.auth-entry__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.auth-entry__chip {
+    padding: 0.55rem 0.85rem;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    border-radius: 9999px;
+    background: rgba(255, 255, 255, 0.08);
+    color: rgba(255, 247, 237, 0.9);
+    font-size: 0.88rem;
+    font-weight: 600;
+}
+
+.auth-entry__panel-card {
+    margin-top: 1.35rem;
+    padding: 1.1rem 1rem;
+    border-radius: 1.4rem;
+    background: rgba(255, 255, 255, 0.06);
+}
+
+.auth-entry__panel-label {
+    margin: 0;
+    color: #fde68a;
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+}
+
+.auth-entry__panel-copy {
+    margin: 0.7rem 0 0;
+    color: rgba(255, 247, 237, 0.82);
+    font-size: 0.96rem;
+    line-height: 1.7;
+}
+
+.auth-entry__login-shell {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: calc(100vh - 11rem);
+}
+
+.auth-entry__login-card {
+    width: min(100%, 32rem);
+    text-align: center;
+}
+
+.auth-entry__status {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.7rem;
+    margin-top: 1.8rem;
+    padding: 0.85rem 1.1rem;
+    border-radius: 9999px;
+    background: rgba(255, 255, 255, 0.08);
+    color: rgba(255, 247, 237, 0.9);
+    font-size: 0.95rem;
+    font-weight: 600;
+}
+
+.auth-entry__status-dot {
+    width: 0.8rem;
+    height: 0.8rem;
+    border-radius: 9999px;
+    background: #fde68a;
+    box-shadow: 0 0 0 0 rgba(253, 230, 138, 0.5);
+    animation: authEntryPulse 1.8s ease-in-out infinite;
+}
+
+.auth-entry__link {
+    color: #fde68a;
+    font-size: 0.95rem;
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.auth-entry__link:hover {
+    text-decoration: underline;
+}
+
+@keyframes authEntryPulse {
+    0% {
+        box-shadow: 0 0 0 0 rgba(253, 230, 138, 0.5);
+    }
+
+    70% {
+        box-shadow: 0 0 0 0.55rem rgba(253, 230, 138, 0);
+    }
+
+    100% {
+        box-shadow: 0 0 0 0 rgba(253, 230, 138, 0);
+    }
+}
+
+@media (max-width: 900px) {
+    .auth-entry__hero {
+        grid-template-columns: 1fr;
+        justify-items: start;
+        padding-top: 2rem;
+    }
+
+    .auth-entry__panel {
+        width: min(100%, 28rem);
+    }
+
+    .auth-entry__login-shell {
+        min-height: calc(100vh - 10rem);
+    }
+}
+
+@media (max-width: 640px) {
+    .auth-entry__shell,
+    .auth-entry__shell--compact {
+        padding: 1.25rem;
+    }
+
+    .auth-entry__brand {
+        align-items: center;
+    }
+
+    .auth-entry__brand-name {
+        font-size: 1rem;
+    }
+
+    .auth-entry__brand-line {
+        font-size: 0.88rem;
+    }
+
+    .auth-entry__title {
+        font-size: clamp(2.3rem, 12vw, 3.4rem);
+    }
+
+    .auth-entry__title--compact {
+        font-size: clamp(1.9rem, 9vw, 2.5rem);
+    }
+
+    .auth-entry__actions {
+        width: 100%;
+    }
+
+    .auth-entry__button {
+        width: 100%;
+    }
+
+    .auth-entry__panel,
+    .auth-entry__login-card {
+        width: 100%;
+        border-radius: 1.5rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .auth-entry__button,
+    .auth-entry__status-dot {
+        transition: none;
+        animation: none;
+    }
+}


### PR DESCRIPTION
## Summary
This PR updates the One Portal authentication flow so users enter through a dedicated landing page, continue to the IDP login page, and return into `/portal` after successful sign-in. It also aligns the frontend with the updated auth endpoint responses and redirects users back to `/landingRoute` after logout.

## What Changed
- Added a public landing page for One Portal entry
- Added a dedicated `/login` route for the IDP handoff flow
- Updated app routing so `/` and `/landingRoute` can detect auth callback params and finish login instead of showing the landing page
- Added a callback-safe flow that redirects authenticated users into `/portal`
- Updated frontend authorization to call `/auth/authorize`, read the returned redirect URL, and navigate with `window.location.href`
- Prevented repeated `/auth/authorize` and `/auth/callback` requests during the same auth attempt
- Updated portal-side unauthenticated/session-expired handling to route users through the login page
- Added a new shared auth-entry design for the landing and login experience
- Updated logout fallback behavior so users are redirected to `/landingRoute`
- Aligned auth handler responses/config usage to support the frontend-controlled redirect flow

## User Flow
1. User opens the landing page
2. User selects `Login` or `Register`
3. Frontend routes to `/login`
4. `/login` requests `/auth/authorize` and opens the IDP page
5. After successful IDP login, the frontend completes authorization
6. User is redirected to `/portal`
7. On logout, the user is redirected to `/landingRoute`

## Testing
- `npm run build` in `frontend`

## Notes
- The landing page and login entry flow now use a shared Poppins-based auth design
- The frontend now handles both `/callback` and root-level auth return params more safely
