### PR TITLE
remove API key authentication middleware from v1 API routes

### DIFF
--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -39,7 +39,6 @@ func (r *Routes) Register(router *gin.Engine) {
 	apiGroup := router.Group("/api")
 	v1Group := apiGroup.Group("/v1")
 
-	v1Group.Use(middleware.APIKeyAuthMiddleware)
 	v1Group.GET("/logs", r.LogHandler.HandleGetLogs)
 	v1Group.GET("/announcement", r.Announcement.HandleGetAnnouncement)
 


### PR DESCRIPTION
This pull request makes a small change to the API routing setup by removing the `APIKeyAuthMiddleware` from the `/api/v1` group. This means that endpoints under `/api/v1` will no longer require API key authentication.

* Removed the `APIKeyAuthMiddleware` from the `/api/v1` route group in `routes.go`, making the `/logs` and `/announcement` endpoints publicly accessible.