### PR TITLE
fix staticcheck ST1005 error string capitalization

### DIFF
--- a/backend/internal/database/connection.go
+++ b/backend/internal/database/connection.go
@@ -25,7 +25,7 @@ func ConnectAdminToDB() (*sqlx.DB, error) {
 
 	db, err := sqlx.Open("mysql", config.FormatDSN())
 	if err != nil {
-		return nil, fmt.Errorf("Error connecting to database: %w", err)
+		return nil, fmt.Errorf("error connecting to database: %w", err)
 	}
 
 	return db, nil
@@ -46,7 +46,7 @@ func ConnectToDB() (*sqlx.DB, error) {
 
 	db, err := sqlx.Open("mysql", config.FormatDSN())
 	if err != nil {
-		return nil, fmt.Errorf("Error connecting to database: %w", err)
+		return nil, fmt.Errorf("error connecting to database: %w", err)
 	}
 
 	maxConnections := 25
@@ -60,7 +60,7 @@ func ConnectToDB() (*sqlx.DB, error) {
 		db.Close()
 
 		return nil, fmt.Errorf(
-			"Error pinging the database at %s: %w", 
+			"error pinging the database at %s: %w", 
 			config.Addr, 
 			err,
 		)


### PR DESCRIPTION
This pull request makes minor improvements to error message formatting in the `backend/internal/database/connection.go` file. Specifically, it standardizes the capitalization of error messages to start with a lowercase letter for consistency.

- Error message formatting:
  * Standardized all error messages in `ConnectAdminToDB` and `ConnectToDB` functions to start with a lowercase letter instead of "Error" [[1]](diffhunk://#diff-6b8e9f50b5fc06b2a265a5624381b7670734c45a0004fbe20b7f2019af91a083L28-R28) [[2]](diffhunk://#diff-6b8e9f50b5fc06b2a265a5624381b7670734c45a0004fbe20b7f2019af91a083L49-R49) [[3]](diffhunk://#diff-6b8e9f50b5fc06b2a265a5624381b7670734c45a0004fbe20b7f2019af91a083L63-R63)