### PR TITLE
Update CI/CD deployment logic to clean containers before deploy

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -100,14 +100,36 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Copy Compose file to Staging
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.STAGING_IP }}
-          username: ${{ secrets.STAGING_USER }}
-          key: ${{ secrets.STAGING_SSH_PK }}
-          source: "docker-compose.ghcr.yml"
-          target: "~/One-Portal"
+      - name: Clean Staging App Images and Copy Compose file
+        env:
+          STAGING_HOST: ${{ secrets.STAGING_IP }}
+          STAGING_USER: ${{ secrets.STAGING_USER }}
+          STAGING_KEY: ${{ secrets.STAGING_SSH_PK }}
+        run: |
+          install -m 700 -d "$HOME/.ssh"
+          printf '%s' "$STAGING_KEY" > "$HOME/.ssh/staging_key"
+          chmod 600 "$HOME/.ssh/staging_key"
+          ssh -i "$HOME/.ssh/staging_key" \
+            -o StrictHostKeyChecking=no \
+            -o UserKnownHostsFile=/dev/null \
+            "$STAGING_USER@$STAGING_HOST" \
+            '
+            set -e
+            APP_DIR="$HOME/One-Portal"
+            COMPOSE_FILE="$APP_DIR/docker-compose.ghcr.yml"
+
+            mkdir -p "$APP_DIR"
+            chmod 755 "$APP_DIR"
+
+            docker rm -f one_portal_backend one_portal_frontend >/dev/null 2>&1 || true
+            docker image rm -f \
+              ghcr.io/iskolutions-capstone-dev-team/one-portal-backend:latest \
+              ghcr.io/iskolutions-capstone-dev-team/one-portal-frontend:latest \
+              >/dev/null 2>&1 || true
+
+            cat > "$COMPOSE_FILE"
+            ' \
+            < docker-compose.ghcr.yml
 
       - name: Deploy to Staging
         uses: appleboy/ssh-action@v1.0.3
@@ -116,7 +138,7 @@ jobs:
           username: ${{ secrets.STAGING_USER }}
           key: ${{ secrets.STAGING_SSH_PK }}
           script: |
-            cd One-Portal/
+            cd "$HOME/One-Portal"
             git pull origin development
             echo "${{ secrets.GH_PAT }}" | \
               docker login ghcr.io -u ${{ secrets.GH_USERNAME }} \
@@ -132,14 +154,36 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Copy Compose file to Production
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.VPS_IP }}
-          username: ${{ secrets.VPS_USER }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: "docker-compose.ghcr.yml"
-          target: "~/One-Portal"
+      - name: Clean Production App Images and Copy Compose file
+        env:
+          PRODUCTION_HOST: ${{ secrets.VPS_IP }}
+          PRODUCTION_USER: ${{ secrets.VPS_USER }}
+          PRODUCTION_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: |
+          install -m 700 -d "$HOME/.ssh"
+          printf '%s' "$PRODUCTION_KEY" > "$HOME/.ssh/production_key"
+          chmod 600 "$HOME/.ssh/production_key"
+          ssh -i "$HOME/.ssh/production_key" \
+            -o StrictHostKeyChecking=no \
+            -o UserKnownHostsFile=/dev/null \
+            "$PRODUCTION_USER@$PRODUCTION_HOST" \
+            '
+            set -e
+            APP_DIR="$HOME/One-Portal"
+            COMPOSE_FILE="$APP_DIR/docker-compose.ghcr.yml"
+
+            mkdir -p "$APP_DIR"
+            chmod 755 "$APP_DIR"
+
+            docker rm -f one_portal_backend one_portal_frontend >/dev/null 2>&1 || true
+            docker image rm -f \
+              ghcr.io/iskolutions-capstone-dev-team/one-portal-backend:latest \
+              ghcr.io/iskolutions-capstone-dev-team/one-portal-frontend:latest \
+              >/dev/null 2>&1 || true
+
+            cat > "$COMPOSE_FILE"
+            ' \
+            < docker-compose.ghcr.yml
 
       - name: Deploy to Production
         uses: appleboy/ssh-action@v1.0.3
@@ -148,7 +192,7 @@ jobs:
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
-            cd One-Portal/
+            cd "$HOME/One-Portal"
             git pull origin main
             echo "${{ secrets.GH_PAT }}" | \
               docker login ghcr.io -u ${{ secrets.GH_USERNAME }} \


### PR DESCRIPTION
This pull request updates the CI/CD workflow to improve the deployment process for both staging and production environments. The main changes involve replacing the use of the `scp-action` for copying files with custom SSH commands that also clean up old Docker containers and images before deploying the new compose file. Additionally, directory navigation in deployment scripts is now more robust by using an explicit home directory reference.

**Deployment process improvements:**

* Replaced the `appleboy/scp-action` with custom SSH commands in both staging and production jobs, allowing for pre-deployment cleanup of old Docker containers and images and more secure, controlled file copying of `docker-compose.ghcr.yml`. [[1]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L103-R132) [[2]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L135-R186)
* Updated the deployment script to use `cd "$HOME/One-Portal"` instead of a relative path, ensuring the script works regardless of the working directory. [[1]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L119-R141) [[2]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L151-R195)