### PR TITLE
Refine CI/CD deployment and fix service configurations

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -100,14 +100,36 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Copy Compose file to Staging
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.STAGING_IP }}
-          username: ${{ secrets.STAGING_USER }}
-          key: ${{ secrets.STAGING_SSH_PK }}
-          source: "docker-compose.ghcr.yml"
-          target: "~/One-Portal"
+      - name: Clean Staging App Images and Copy Compose file
+        env:
+          STAGING_HOST: ${{ secrets.STAGING_IP }}
+          STAGING_USER: ${{ secrets.STAGING_USER }}
+          STAGING_KEY: ${{ secrets.STAGING_SSH_PK }}
+        run: |
+          install -m 700 -d "$HOME/.ssh"
+          printf '%s' "$STAGING_KEY" > "$HOME/.ssh/staging_key"
+          chmod 600 "$HOME/.ssh/staging_key"
+          ssh -i "$HOME/.ssh/staging_key" \
+            -o StrictHostKeyChecking=no \
+            -o UserKnownHostsFile=/dev/null \
+            "$STAGING_USER@$STAGING_HOST" \
+            '
+            set -e
+            APP_DIR="$HOME/One-Portal"
+            COMPOSE_FILE="$APP_DIR/docker-compose.ghcr.yml"
+
+            mkdir -p "$APP_DIR"
+            chmod 755 "$APP_DIR"
+
+            docker rm -f one_portal_backend one_portal_frontend >/dev/null 2>&1 || true
+            docker image rm -f \
+              ghcr.io/iskolutions-capstone-dev-team/one-portal-backend:latest \
+              ghcr.io/iskolutions-capstone-dev-team/one-portal-frontend:latest \
+              >/dev/null 2>&1 || true
+
+            cat > "$COMPOSE_FILE"
+            ' \
+            < docker-compose.ghcr.yml
 
       - name: Deploy to Staging
         uses: appleboy/ssh-action@v1.0.3
@@ -116,7 +138,7 @@ jobs:
           username: ${{ secrets.STAGING_USER }}
           key: ${{ secrets.STAGING_SSH_PK }}
           script: |
-            cd One-Portal/
+            cd "$HOME/One-Portal"
             git pull origin development
             echo "${{ secrets.GH_PAT }}" | \
               docker login ghcr.io -u ${{ secrets.GH_USERNAME }} \
@@ -132,14 +154,36 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Copy Compose file to Production
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.VPS_IP }}
-          username: ${{ secrets.VPS_USER }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: "docker-compose.ghcr.yml"
-          target: "~/One-Portal"
+      - name: Clean Production App Images and Copy Compose file
+        env:
+          PRODUCTION_HOST: ${{ secrets.VPS_IP }}
+          PRODUCTION_USER: ${{ secrets.VPS_USER }}
+          PRODUCTION_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: |
+          install -m 700 -d "$HOME/.ssh"
+          printf '%s' "$PRODUCTION_KEY" > "$HOME/.ssh/production_key"
+          chmod 600 "$HOME/.ssh/production_key"
+          ssh -i "$HOME/.ssh/production_key" \
+            -o StrictHostKeyChecking=no \
+            -o UserKnownHostsFile=/dev/null \
+            "$PRODUCTION_USER@$PRODUCTION_HOST" \
+            '
+            set -e
+            APP_DIR="$HOME/One-Portal"
+            COMPOSE_FILE="$APP_DIR/docker-compose.ghcr.yml"
+
+            mkdir -p "$APP_DIR"
+            chmod 755 "$APP_DIR"
+
+            docker rm -f one_portal_backend one_portal_frontend >/dev/null 2>&1 || true
+            docker image rm -f \
+              ghcr.io/iskolutions-capstone-dev-team/one-portal-backend:latest \
+              ghcr.io/iskolutions-capstone-dev-team/one-portal-frontend:latest \
+              >/dev/null 2>&1 || true
+
+            cat > "$COMPOSE_FILE"
+            ' \
+            < docker-compose.ghcr.yml
 
       - name: Deploy to Production
         uses: appleboy/ssh-action@v1.0.3
@@ -148,7 +192,7 @@ jobs:
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
-            cd One-Portal/
+            cd "$HOME/One-Portal"
             git pull origin main
             echo "${{ secrets.GH_PAT }}" | \
               docker login ghcr.io -u ${{ secrets.GH_USERNAME }} \

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -19,7 +19,7 @@ services:
     networks:
       - one_portal_network
     depends_on:
-      db:
+      oneportal_database:
         condition: service_healthy
 
   # One Portal Frontend (GHCR Image)
@@ -43,9 +43,9 @@ services:
       - backend
 
   # Database Service
-  db:
+  oneportal_database:
     image: mysql:8.4
-    container_name: unified_access_database
+    container_name: one_portal_database
     restart: always
     environment:
       MYSQL_DATABASE: ${MYSQL_DB_NAME}
@@ -68,51 +68,8 @@ services:
       timeout: 5s
       retries: 5
 
-  # Minio (S3-Like storage)
-  minio:
-    image: minio/minio:latest
-    container_name: one_portal_minio
-    restart: always
-    command: server /data --console-address ":9001"
-    environment:
-      MINIO_ROOT_USER: ${S3_KEY}
-      MINIO_ROOT_PASSWORD: ${S3_SECRET}
-    ports:
-      - "9000:9000"
-      - "9001:9001"
-    volumes:
-      - minio_data:/data
-    networks:
-      - one_portal_network
-      
-  # Minio Setup Service
-  minio_init:
-    image: quay.io/minio/mc:latest
-    container_name: one_portal_minio_setup
-    depends_on:
-      - minio
-    networks:
-      - one_portal_network
-    environment:
-      - S3_KEY=${S3_KEY}
-      - S3_SECRET=${S3_SECRET}
-      - S3_BUCKET=${S3_BUCKET}
-    entrypoint: >
-      /bin/sh -c "
-      sleep 5;
-      mc alias set local http://minio:9000 ${S3_KEY} ${S3_SECRET};
-      mc mb local/${S3_BUCKET} --ignore-existing;
-      mc anonymous set download local/${S3_BUCKET};
-      JSON='[{\"AllowedOrigins\":[\"*\"],\"AllowedMethods\":[\"GET\"]}';
-      JSON=\"$${JSON},\"'\"AllowedHeaders\":[\"*\"]}]';
-      echo $$JSON > /tmp/cors.json;
-      mc cors set local/${S3_BUCKET} /tmp/cors.json;
-      exit 0;
-      "
-
 volumes:
   db_data:
-  minio_data:
 
 networks:
   one_portal_network:

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -34,8 +34,7 @@ services:
       VITE_CLIENT_SECRET: ${VITE_CLIENT_SECRET}
       VITE_BACKEND_URL: ${VITE_BACKEND_URL}
       VITE_BACKEND_API_KEY: ${VITE_BACKEND_API_KEY}
-      VITE_ONE_PORTAL_URL: ${VITE_ONE_PORTAL_URL}
-      BACKEND_PROXY_TARGET: ${BACKEND_PROXY_TARGET}
+      VITE_PROXY_TARGET_URL: ${VITE_PROXY_TARGET_URL}
     ports:
       - "5173:5173"
     networks:
@@ -64,7 +63,7 @@ services:
     networks:
       - one_portal_network
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u root -p$${MYSQL_ROOT_PASSWORD}"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -105,8 +104,8 @@ services:
       mc mb local/${S3_BUCKET} --ignore-existing;
       mc anonymous set download local/${S3_BUCKET};
       JSON='[{\"AllowedOrigins\":[\"*\"],\"AllowedMethods\":[\"GET\"]}';
-      JSON=\"${JSON},\"'\"AllowedHeaders\":[\"*\"]}]';
-      echo \$JSON > /tmp/cors.json;
+      JSON=\"$${JSON},\"'\"AllowedHeaders\":[\"*\"]}]';
+      echo $$JSON > /tmp/cors.json;
       mc cors set local/${S3_BUCKET} /tmp/cors.json;
       exit 0;
       "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
     networks:
       - one_portal_network
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u root -p$${MYSQL_ROOT_PASSWORD}"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
This pull request updates the CI/CD pipeline and Docker Compose files to improve deployment reliability and consistency across environments. The main changes include enhancing the deployment workflow to clean up old containers and images before copying the new Compose file, updating service names and environment variables for clarity, and removing the Minio storage service from the Compose configuration.

**CI/CD Workflow Improvements:**

* The GitHub Actions workflow in `.github/workflows/ci-cd.yml` now cleans up old Docker containers and images on both staging and production servers before copying over the new `docker-compose.ghcr.yml` file. This helps ensure that deployments use the latest images and reduces the chance of conflicts. [[1]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L103-R132) [[2]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L135-R186)
* The deployment steps now consistently use `$HOME/One-Portal` as the working directory, improving reliability and clarity in deployment scripts. [[1]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L119-R141) [[2]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L151-R195)

**Docker Compose File Updates:**

* Service names have been standardized: the database service is now called `oneportal_database` instead of `db`, and its container name is `one_portal_database`. All dependencies and health checks have been updated accordingly. [[1]](diffhunk://#diff-853304662c013625dcbd238912cdcc9d9d42985f4e95924ae7fcc81fe43c83c0L22-R22) [[2]](diffhunk://#diff-853304662c013625dcbd238912cdcc9d9d42985f4e95924ae7fcc81fe43c83c0L47-R48)
* The MySQL health check has been improved to use the root password for authentication, ensuring more accurate health reporting. [[1]](diffhunk://#diff-853304662c013625dcbd238912cdcc9d9d42985f4e95924ae7fcc81fe43c83c0L67-L116) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L72-R72)
* Unused or deprecated environment variables have been removed or renamed for clarity (e.g., `VITE_PROXY_TARGET_URL` replaces `VITE_ONE_PORTAL_URL` and `BACKEND_PROXY_TARGET`).

**Service Removal:**

* The Minio object storage service and its initialization container have been removed from the Compose file, along with related volumes and networks. This simplifies the deployment and removes unused dependencies.

These changes collectively streamline the deployment process and make the configuration files easier to maintain.