### PR TITLE
Remove redundant portal from frontend response list

### DIFF
--- a/backend/internal/api/v1/user_access_handler.go
+++ b/backend/internal/api/v1/user_access_handler.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/Iskolutions-Capstone-Dev-Team/One-Portal/internal/dto"
 	"github.com/gin-gonic/gin"
@@ -96,5 +98,23 @@ func (h *UserAccessHandler) GetUserDetailedAccess(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, accessInfo)
+	// 7. Filter out One-Portal's own client from the list
+	selfClientID := os.Getenv("CLIENT_ID")
+	if selfClientID == "" {
+		log.Printf(
+			"[GetUserDetailedAccess] Config: CLIENT_ID env var not set," +
+				" skipping filter",
+		)
+		c.JSON(http.StatusOK, accessInfo)
+		return
+	}
+
+	filtered := make([]dto.ClientDetailedAccessResponse, 0, len(accessInfo))
+	for _, entry := range accessInfo {
+		if !strings.EqualFold(entry.ID, selfClientID) {
+			filtered = append(filtered, entry)
+		}
+	}
+
+	c.JSON(http.StatusOK, filtered)
 }


### PR DESCRIPTION
This pull request updates the `GetUserDetailedAccess` handler to filter out One-Portal's own client from the returned list of client access details. It also introduces additional imports to support this logic.

**Handler logic improvements:**

* Filters out entries in the response where the client ID matches the One-Portal's own `CLIENT_ID` environment variable, preventing the portal from displaying its own client in user access details. If the environment variable is not set, logs a warning and returns the unfiltered list.

**Dependency updates:**

* Adds the `log` and `strings` packages to support logging and case-insensitive string comparison in the handler.