### PR TITLE
Remove redundant portal from frontend response list

### DIFF
--- a/backend/internal/api/v1/user_access_handler.go
+++ b/backend/internal/api/v1/user_access_handler.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/Iskolutions-Capstone-Dev-Team/One-Portal/internal/dto"
 	"github.com/gin-gonic/gin"
@@ -96,5 +98,23 @@ func (h *UserAccessHandler) GetUserDetailedAccess(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, accessInfo)
+	// 7. Filter out One-Portal's own client from the list
+	selfClientID := os.Getenv("CLIENT_ID")
+	if selfClientID == "" {
+		log.Printf(
+			"[GetUserDetailedAccess] Config: CLIENT_ID env var not set," +
+				" skipping filter",
+		)
+		c.JSON(http.StatusOK, accessInfo)
+		return
+	}
+
+	filtered := make([]dto.ClientDetailedAccessResponse, 0, len(accessInfo))
+	for _, entry := range accessInfo {
+		if !strings.EqualFold(entry.ID, selfClientID) {
+			filtered = append(filtered, entry)
+		}
+	}
+
+	c.JSON(http.StatusOK, filtered)
 }


### PR DESCRIPTION
This pull request updates the `GetUserDetailedAccess` handler to filter out One-Portal's own client from the returned list of client access responses. It also adds necessary imports to support the new logic.

**User access response filtering:**

* The handler now retrieves the `CLIENT_ID` environment variable and filters out any client in the response whose ID matches One-Portal's own client ID, making the returned list more relevant for consumers. If `CLIENT_ID` is not set, a log message is printed and the filter is skipped. (`backend/internal/api/v1/user_access_handler.go`)

**Imports:**

* Added `log` and `strings` packages to support logging and case-insensitive string comparison for the filtering logic. (`backend/internal/api/v1/user_access_handler.go`)