### PR TITLE
Add OnePortalLink to ClientDetailedAccessResponse and override BaseURL

### DIFF
--- a/backend/internal/api/v1/user_access_handler.go
+++ b/backend/internal/api/v1/user_access_handler.go
@@ -129,6 +129,12 @@ func (h *UserAccessHandler) GetUserDetailedAccess(c *gin.Context) {
 		return
 	}
 
+	for i := range accessInfo {
+		if accessInfo[i].OnePortalLink != "" {
+			accessInfo[i].BaseURL = accessInfo[i].OnePortalLink
+		}
+	}
+
 	// 9. Filter out One-Portal's own client from the list
 	selfClientID := os.Getenv("CLIENT_ID")
 	if selfClientID == "" {

--- a/backend/internal/dto/user_access_dto.go
+++ b/backend/internal/dto/user_access_dto.go
@@ -19,4 +19,5 @@ type ClientDetailedAccessResponse struct {
 	Description   string `json:"description"`
 	ImageLocation string `json:"image_location"`
 	BaseURL       string `json:"base_url"`
+	OnePortalLink string `json:"one_portal_link"`
 }

--- a/backend/internal/tests/handler/user_access_handler_test.go
+++ b/backend/internal/tests/handler/user_access_handler_test.go
@@ -15,10 +15,15 @@ import (
 func TestUserAccessHandler(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	idpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handlerFunc := http.HandlerFunc(func(
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode([]dto.ClientDetailedAccessResponse{})
-	}))
+	})
+
+	idpServer := httptest.NewServer(handlerFunc)
 	defer idpServer.Close()
 
 	os.Setenv("IDP_ACCESS_URL", idpServer.URL)
@@ -41,5 +46,83 @@ func TestUserAccessHandler(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestUserAccessHandler_OnePortalLinkOverride(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mockClients := []dto.ClientDetailedAccessResponse{
+		{
+			ID:            "client-1",
+			Name:          "Client One",
+			BaseURL:       "http://base-one.com",
+			OnePortalLink: "http://override-one.com",
+		},
+		{
+			ID:            "client-2",
+			Name:          "Client Two",
+			BaseURL:       "http://base-two.com",
+			OnePortalLink: "",
+		},
+	}
+
+	handlerFunc := http.HandlerFunc(func(
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(mockClients)
+	})
+
+	idpServer := httptest.NewServer(handlerFunc)
+	defer idpServer.Close()
+
+	os.Setenv("IDP_ACCESS_URL", idpServer.URL)
+	os.Setenv("VITE_BACKEND_API_KEY", "test-key")
+	defer func() {
+		os.Unsetenv("IDP_ACCESS_URL")
+		os.Unsetenv("VITE_BACKEND_API_KEY")
+	}()
+
+	h := v1.NewUserAccessHandler(nil)
+	r := gin.New()
+	r.GET("/users/access", h.GetUserDetailedAccess)
+
+	req := httptest.NewRequest(http.MethodGet, "/users/access", nil)
+	cookie := &http.Cookie{
+		Name:  "access_token",
+		Value: "token-123",
+	}
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var response []dto.ClientDetailedAccessResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(response) != 2 {
+		t.Fatalf("expected 2 clients, got %d", len(response))
+	}
+
+	if response[0].BaseURL != "http://override-one.com" {
+		t.Errorf(
+			"expected override to http://override-one.com, got %s",
+			response[0].BaseURL,
+		)
+	}
+
+	if response[1].BaseURL != "http://base-two.com" {
+		t.Errorf(
+			"expected base http://base-two.com, got %s",
+			response[1].BaseURL,
+		)
 	}
 }


### PR DESCRIPTION
This pull request enhances the user access API to support an override of the `BaseURL` field with a new `OnePortalLink` value if present, and adds comprehensive testing for this behavior. The main changes introduce a new field to the response DTO, update the handler logic to use it, and add a dedicated test to ensure the override works as expected.

**API Enhancements:**

* Added a new `OnePortalLink` field to the `ClientDetailedAccessResponse` struct, allowing clients to specify an override URL for portal access.
* Updated the `GetUserDetailedAccess` handler to set `BaseURL` to `OnePortalLink` if it is non-empty, ensuring the override is applied in API responses.

**Testing Improvements:**

* Refactored the test handler setup in `user_access_handler_test.go` for improved readability and maintainability.
* Added a new test, `TestUserAccessHandler_OnePortalLinkOverride`, to verify that the `BaseURL` is correctly overridden by `OnePortalLink` when provided, and remains unchanged otherwise.