### PR TITLE
Change logout request to POST and add logout guard

### DIFF
--- a/backend/internal/api/v1/auth_handler.go
+++ b/backend/internal/api/v1/auth_handler.go
@@ -302,14 +302,6 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 
 	// Notify the Identity Provider about the logout
 	url := h.notifyIDPLogout(c)
-	if url != "" {
-		resp, err := Client.Get(url)
-		if err != nil {
-			log.Printf("[Logout] IDP Notification: %v", err)
-		} else {
-			resp.Body.Close()
-		}
-	}
 
 	c.JSON(http.StatusOK, gin.H{"url": url})
 }
@@ -493,20 +485,29 @@ func (h *AuthHandler) notifyIDPLogout(c *gin.Context) string {
 		return logoutURL
 	}
 
-	claims, err := middleware.ValidateAccessToken(accessToken)
-	if err != nil {
-		return logoutURL
-	}
-
-	userID, ok := claims["userId"].(string)
-	if !ok {
-		return logoutURL
-	}
-
-	return fmt.Sprintf(
-		"%s?client_id=%s&user_id=%s",
+	// Create and send a POST request to IDP logout
+	reqBody, _ := json.Marshal(map[string]string{
+		"client_id": clientID,
+	})
+	req, err := http.NewRequest(
+		"POST",
 		logoutURL,
-		clientID,
-		userID,
+		bytes.NewBuffer(reqBody),
 	)
+	if err != nil {
+		log.Printf("[notifyIDPLogout] Create Request: %v", err)
+		return logoutURL
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := Client.Do(req)
+	if err != nil {
+		log.Printf("[notifyIDPLogout] Send POST: %v", err)
+	} else {
+		resp.Body.Close()
+	}
+
+	return logoutURL
 }

--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -3,6 +3,7 @@ import { clearCurrentUserProfileCache } from "./userProfile";
 
 const SESSION_REFRESH_TIMESTAMP_KEY = "one-portal:last-session-refresh-at";
 const AUTHORIZATION_PATH = "/auth/authorize";
+const LOGOUT_API_PATH = "/api/v1/auth/logout";
 const LANDING_ROUTE_PATH = "/landing";
 const SESSION_COOKIE_NAMES = ["access_token", "session_cookie"];
 let authorizationRequestPromise = null;
@@ -200,6 +201,16 @@ function getLogoutResponseUrl(data) {
     return typeof data.url === "string" ? data.url.trim() : "";
 }
 
+function isLogoutApiUrl(logoutUrl) {
+    try {
+        const url = new URL(logoutUrl, window.location.origin);
+        return url.pathname.endsWith(LOGOUT_API_PATH);
+    } catch (error) {
+        console.error("Invalid logout URL.", error);
+        return false;
+    }
+}
+
 function getAuthorizationLocationUrl(response) {
     const location = response.headers.get("location");
 
@@ -314,6 +325,10 @@ export function clearSessionCookies() {
 
 async function notifyBrowserLogout(logoutUrl) {
     if (!logoutUrl || !hasDocument() || !document.body) {
+        return;
+    }
+
+    if (isLogoutApiUrl(logoutUrl)) {
         return;
     }
 


### PR DESCRIPTION
This pull request updates the logout flow to improve security and reliability by changing how the backend notifies the Identity Provider (IDP) of a logout, and by refining the frontend's handling of logout URLs. The backend now sends a POST request with proper authorization to the IDP, and the frontend ensures it doesn't redundantly trigger logout actions for internal API endpoints.

**Backend logout notification improvements:**

* The backend (`auth_handler.go`) now sends a POST request to the IDP logout endpoint, including the `client_id` in the JSON body and the access token in the `Authorization` header, instead of constructing a GET request with query parameters. This ensures secure and standards-compliant communication with the IDP.
* Removed the redundant backend GET request to the IDP logout URL in the `Logout` handler, as this is now handled by the improved POST logic.

**Frontend logout handling improvements:**

* Added `LOGOUT_API_PATH` constant to centralize the logout API path in the frontend service.
* Introduced `isLogoutApiUrl` utility to detect if a logout URL points to the internal API, preventing unnecessary or recursive logout actions.
* Updated `notifyBrowserLogout` to skip iframe-based logout notifications when the URL is the internal logout API, avoiding redundant requests.