### PR TITLE
Implement passkey proxy with DTO and unit tests

### DIFF
--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -78,6 +78,35 @@ func (r *Routes) Register(router *gin.Engine) {
 			r.MFA.GetAuthenticatorList,
 		)
 		mfaGroup.DELETE("/authenticators", mfaRL, r.MFA.DeleteAuthenticator)
+
+		// Passkey verification
+		mfaGroup.POST(
+			"/passkey/verify/begin",
+			mfaRL,
+			r.MFA.BeginPasskeyVerification,
+		)
+		mfaGroup.POST(
+			"/passkey/verify/finish",
+			mfaRL,
+			r.MFA.FinishPasskeyVerification,
+		)
+		mfaGroup.GET(
+			"/passkey/exists",
+			mfaRL,
+			r.MFA.GetHasPasskey,
+		)
+
+		// Passkey registration
+		mfaGroup.POST(
+			"/passkey/register/begin",
+			mfaRL,
+			r.MFA.BeginPasskeyRegistration,
+		)
+		mfaGroup.POST(
+			"/passkey/register/finish",
+			mfaRL,
+			r.MFA.FinishPasskeyRegistration,
+		)
 	}
 
 	// --- JWT-protected endpoints (user session required) ---

--- a/backend/internal/api/v1/mfa_handler.go
+++ b/backend/internal/api/v1/mfa_handler.go
@@ -415,6 +415,353 @@ func (h *MFAHandler) DeleteAuthenticator(c *gin.Context) {
 	c.JSON(http.StatusOK, delResp)
 }
 
+// BeginPasskeyVerification starts passkey verification ceremony.
+func (h *MFAHandler) BeginPasskeyVerification(c *gin.Context) {
+	var req dto.PasskeyBeginRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		log.Printf("[BeginPasskeyVerification] {Bind JSON}: %v", err)
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Error: err.Error(),
+		})
+		return
+	}
+
+	idpBase := os.Getenv("IDP_MFA_URL")
+	if idpBase == "" {
+		idpBase = "http://localhost:8080/api/v1/mfa"
+	}
+	idpURL := fmt.Sprintf("%s/passkey/verify/begin", idpBase)
+
+	body, _ := json.Marshal(req)
+	proxyReq, err := http.NewRequest(
+		http.MethodPost,
+		idpURL,
+		bytes.NewBuffer(body),
+	)
+	if err != nil {
+		log.Printf("[BeginPasskeyVerification] {Build Request}: %v", err)
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Error: "Failed to build request",
+		})
+		return
+	}
+	proxyReq.Header.Set("Content-Type", "application/json")
+	proxyReq.Header.Set("X-API-Key", os.Getenv("VITE_BACKEND_API_KEY"))
+	if token := getAccessToken(c); token != "" {
+		proxyReq.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := Client.Do(proxyReq)
+	if err != nil {
+		log.Printf("[BeginPasskeyVerification] {IDP Request}: %v", err)
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Error: "Failed to begin passkey verification",
+		})
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp dto.ErrorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&errResp); err == nil {
+			c.JSON(resp.StatusCode, errResp)
+		} else {
+			c.JSON(resp.StatusCode, dto.ErrorResponse{
+				Error: "Passkey verification begin failed in IDP",
+			})
+		}
+		return
+	}
+
+	// Forward the raw challenge bytes directly to browser
+	c.DataFromReader(
+		resp.StatusCode,
+		resp.ContentLength,
+		resp.Header.Get("Content-Type"),
+		resp.Body,
+		nil,
+	)
+}
+
+// FinishPasskeyVerification completes passkey verification ceremony.
+func (h *MFAHandler) FinishPasskeyVerification(c *gin.Context) {
+	email := c.Query("email")
+	if email == "" {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Error: "Email parameter is required",
+		})
+		return
+	}
+
+	idpBase := os.Getenv("IDP_MFA_URL")
+	if idpBase == "" {
+		idpBase = "http://localhost:8080/api/v1/mfa"
+	}
+	idpURL := fmt.Sprintf(
+		"%s/passkey/verify/finish?email=%s",
+		idpBase,
+		url.QueryEscape(email),
+	)
+
+	proxyReq, err := http.NewRequest(
+		http.MethodPost,
+		idpURL,
+		c.Request.Body,
+	)
+	if err != nil {
+		log.Printf("[FinishPasskeyVerification] {Build Request}: %v", err)
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Error: "Failed to build request",
+		})
+		return
+	}
+	proxyReq.Header.Set("Content-Type", "application/json")
+	proxyReq.Header.Set("X-API-Key", os.Getenv("VITE_BACKEND_API_KEY"))
+	if token := getAccessToken(c); token != "" {
+		proxyReq.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := Client.Do(proxyReq)
+	if err != nil {
+		log.Printf("[FinishPasskeyVerification] {IDP Request}: %v", err)
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Error: "Failed to finish passkey verification",
+		})
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp dto.ErrorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&errResp); err == nil {
+			c.JSON(resp.StatusCode, errResp)
+		} else {
+			c.JSON(resp.StatusCode, dto.ErrorResponse{
+				Error: "Passkey verification finish failed in IDP",
+			})
+		}
+		return
+	}
+
+	var finishResp dto.SuccessResponse
+	if err := json.NewDecoder(resp.Body).Decode(&finishResp); err != nil {
+		log.Printf("[FinishPasskeyVerification] {Decode Resp}: %v", err)
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Error: "Failed to decode response",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, finishResp)
+}
+
+// GetHasPasskey checks if the user has a registered passkey.
+func (h *MFAHandler) GetHasPasskey(c *gin.Context) {
+	email := c.Query("email")
+	if email == "" {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Error: "Email parameter is required",
+		})
+		return
+	}
+
+	idpBase := os.Getenv("IDP_MFA_URL")
+	if idpBase == "" {
+		idpBase = "http://localhost:8080/api/v1/mfa"
+	}
+	idpURL := fmt.Sprintf(
+		"%s/passkey/exists?email=%s",
+		idpBase,
+		url.QueryEscape(email),
+	)
+
+	proxyReq, err := http.NewRequest(http.MethodGet, idpURL, nil)
+	if err != nil {
+		log.Printf("[GetHasPasskey] {Build Request}: %v", err)
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Error: "Failed to build request",
+		})
+		return
+	}
+	proxyReq.Header.Set("X-API-Key", os.Getenv("VITE_BACKEND_API_KEY"))
+	if token := getAccessToken(c); token != "" {
+		proxyReq.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := Client.Do(proxyReq)
+	if err != nil {
+		log.Printf("[GetHasPasskey] {IDP Request}: %v", err)
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Error: "Failed to check passkey existence",
+		})
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp dto.ErrorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&errResp); err == nil {
+			c.JSON(resp.StatusCode, errResp)
+		} else {
+			c.JSON(resp.StatusCode, dto.ErrorResponse{
+				Error: "Passkey existence check failed in IDP",
+			})
+		}
+		return
+	}
+
+	var existsResp map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&existsResp); err != nil {
+		log.Printf("[GetHasPasskey] {Decode Resp}: %v", err)
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Error: "Failed to decode response",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, existsResp)
+}
+
+// BeginPasskeyRegistration starts passkey registration ceremony.
+func (h *MFAHandler) BeginPasskeyRegistration(c *gin.Context) {
+	var req dto.PasskeyBeginRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		log.Printf("[BeginPasskeyRegistration] {Bind JSON}: %v", err)
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Error: err.Error(),
+		})
+		return
+	}
+
+	idpBase := os.Getenv("IDP_MFA_URL")
+	if idpBase == "" {
+		idpBase = "http://localhost:8080/api/v1/mfa"
+	}
+	idpURL := fmt.Sprintf("%s/passkey/register/begin", idpBase)
+
+	body, _ := json.Marshal(req)
+	proxyReq, err := http.NewRequest(
+		http.MethodPost,
+		idpURL,
+		bytes.NewBuffer(body),
+	)
+	if err != nil {
+		log.Printf("[BeginPasskeyRegistration] {Build Request}: %v", err)
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Error: "Failed to build request",
+		})
+		return
+	}
+	proxyReq.Header.Set("Content-Type", "application/json")
+	proxyReq.Header.Set("X-API-Key", os.Getenv("VITE_BACKEND_API_KEY"))
+	if token := getAccessToken(c); token != "" {
+		proxyReq.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := Client.Do(proxyReq)
+	if err != nil {
+		log.Printf("[BeginPasskeyRegistration] {IDP Request}: %v", err)
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Error: "Failed to begin passkey registration",
+		})
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp dto.ErrorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&errResp); err == nil {
+			c.JSON(resp.StatusCode, errResp)
+		} else {
+			c.JSON(resp.StatusCode, dto.ErrorResponse{
+				Error: "Passkey registration begin failed in IDP",
+			})
+		}
+		return
+	}
+
+	// Forward the raw challenge bytes directly to browser
+	c.DataFromReader(
+		resp.StatusCode,
+		resp.ContentLength,
+		resp.Header.Get("Content-Type"),
+		resp.Body,
+		nil,
+	)
+}
+
+// FinishPasskeyRegistration completes passkey registration ceremony.
+func (h *MFAHandler) FinishPasskeyRegistration(c *gin.Context) {
+	email := c.Query("email")
+	if email == "" {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Error: "Email parameter is required",
+		})
+		return
+	}
+
+	idpBase := os.Getenv("IDP_MFA_URL")
+	if idpBase == "" {
+		idpBase = "http://localhost:8080/api/v1/mfa"
+	}
+	idpURL := fmt.Sprintf(
+		"%s/passkey/register/finish?email=%s",
+		idpBase,
+		url.QueryEscape(email),
+	)
+
+	proxyReq, err := http.NewRequest(
+		http.MethodPost,
+		idpURL,
+		c.Request.Body,
+	)
+	if err != nil {
+		log.Printf("[FinishPasskeyRegistration] {Build Request}: %v", err)
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Error: "Failed to build request",
+		})
+		return
+	}
+	proxyReq.Header.Set("Content-Type", "application/json")
+	proxyReq.Header.Set("X-API-Key", os.Getenv("VITE_BACKEND_API_KEY"))
+	if token := getAccessToken(c); token != "" {
+		proxyReq.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := Client.Do(proxyReq)
+	if err != nil {
+		log.Printf("[FinishPasskeyRegistration] {IDP Request}: %v", err)
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Error: "Failed to finish passkey registration",
+		})
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp dto.ErrorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&errResp); err == nil {
+			c.JSON(resp.StatusCode, errResp)
+		} else {
+			c.JSON(resp.StatusCode, dto.ErrorResponse{
+				Error: "Passkey registration finish failed in IDP",
+			})
+		}
+		return
+	}
+
+	var finishResp dto.SuccessResponse
+	if err := json.NewDecoder(resp.Body).Decode(&finishResp); err != nil {
+		log.Printf("[FinishPasskeyRegistration] {Decode Resp}: %v", err)
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Error: "Failed to decode response",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, finishResp)
+}
+
 // getAccessToken extracts JWT access token from cookie or header.
 func getAccessToken(c *gin.Context) string {
 	tStr, err := c.Cookie(dto.AccessCookieName)

--- a/backend/internal/dto/mfa_dto.go
+++ b/backend/internal/dto/mfa_dto.go
@@ -38,3 +38,8 @@ type MFAAuthenticatorResponse struct {
 	CreatedAt  time.Time  `json:"created_at"`
 	LastUsedAt *time.Time `json:"last_used_at"`
 }
+
+// PasskeyBeginRequest is used to start a passkey registration/verification.
+type PasskeyBeginRequest struct {
+	Email string `json:"email" binding:"required"`
+}

--- a/backend/internal/dto/mfa_dto.go
+++ b/backend/internal/dto/mfa_dto.go
@@ -41,5 +41,6 @@ type MFAAuthenticatorResponse struct {
 
 // PasskeyBeginRequest is used to start a passkey registration/verification.
 type PasskeyBeginRequest struct {
-	Email string `json:"email" binding:"required"`
+	Email             string `json:"email" binding:"required"`
+	PlatformAvailable *bool  `json:"platform_available"`
 }

--- a/backend/internal/tests/handler/mfa_handler_test.go
+++ b/backend/internal/tests/handler/mfa_handler_test.go
@@ -244,3 +244,208 @@ func TestMFAHandler_DeleteAuthenticator(t *testing.T) {
 		t.Errorf("expected 200, got %d", w.Code)
 	}
 }
+
+func TestMFAHandler_BeginPasskeyVerification(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	idpServer := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			var payload dto.PasskeyBeginRequest
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatal(err)
+			}
+			if payload.Email != "test@example.com" {
+				t.Errorf("expected test@example.com, got %s", payload.Email)
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"challenge":"mock challenge"}`))
+		},
+	))
+	defer idpServer.Close()
+
+	os.Setenv("IDP_MFA_URL", idpServer.URL)
+	defer os.Unsetenv("IDP_MFA_URL")
+
+	h := v1.NewMFAHandler()
+	r := gin.New()
+	r.POST("/api/v1/mfa/passkey/verify/begin", h.BeginPasskeyVerification)
+
+	reqBody := dto.PasskeyBeginRequest{
+		Email: "test@example.com",
+	}
+	body, _ := json.Marshal(reqBody)
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/mfa/passkey/verify/begin",
+		bytes.NewBuffer(body),
+	)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestMFAHandler_FinishPasskeyVerification(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	idpServer := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			email := r.URL.Query().Get("email")
+			if email != "test@example.com" {
+				t.Errorf("expected test@example.com, got %s", email)
+			}
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(dto.SuccessResponse{
+				Message: "verified",
+			})
+		},
+	))
+	defer idpServer.Close()
+
+	os.Setenv("IDP_MFA_URL", idpServer.URL)
+	defer os.Unsetenv("IDP_MFA_URL")
+
+	h := v1.NewMFAHandler()
+	r := gin.New()
+	r.POST("/api/v1/mfa/passkey/verify/finish", h.FinishPasskeyVerification)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/mfa/passkey/verify/finish?email=test@example.com",
+		bytes.NewBuffer([]byte(`{"id":"cred-1"}`)),
+	)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestMFAHandler_GetHasPasskey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	idpServer := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet {
+				t.Errorf("expected GET, got %s", r.Method)
+			}
+			email := r.URL.Query().Get("email")
+			if email != "test@example.com" {
+				t.Errorf("expected test@example.com, got %s", email)
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"has_passkey":true}`))
+		},
+	))
+	defer idpServer.Close()
+
+	os.Setenv("IDP_MFA_URL", idpServer.URL)
+	defer os.Unsetenv("IDP_MFA_URL")
+
+	h := v1.NewMFAHandler()
+	r := gin.New()
+	r.GET("/api/v1/mfa/passkey/exists", h.GetHasPasskey)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v1/mfa/passkey/exists?email=test@example.com",
+		nil,
+	)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestMFAHandler_BeginPasskeyRegistration(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	idpServer := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			var payload dto.PasskeyBeginRequest
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatal(err)
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"challenge":"mock challenge"}`))
+		},
+	))
+	defer idpServer.Close()
+
+	os.Setenv("IDP_MFA_URL", idpServer.URL)
+	defer os.Unsetenv("IDP_MFA_URL")
+
+	h := v1.NewMFAHandler()
+	r := gin.New()
+	r.POST("/api/v1/mfa/passkey/register/begin", h.BeginPasskeyRegistration)
+
+	reqBody := dto.PasskeyBeginRequest{
+		Email: "test@example.com",
+	}
+	body, _ := json.Marshal(reqBody)
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/mfa/passkey/register/begin",
+		bytes.NewBuffer(body),
+	)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestMFAHandler_FinishPasskeyRegistration(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	idpServer := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			email := r.URL.Query().Get("email")
+			if email != "test@example.com" {
+				t.Errorf("expected test@example.com, got %s", email)
+			}
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(dto.SuccessResponse{
+				Message: "registered",
+			})
+		},
+	))
+	defer idpServer.Close()
+
+	os.Setenv("IDP_MFA_URL", idpServer.URL)
+	defer os.Unsetenv("IDP_MFA_URL")
+
+	h := v1.NewMFAHandler()
+	r := gin.New()
+	r.POST("/api/v1/mfa/passkey/register/finish", h.FinishPasskeyRegistration)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/mfa/passkey/register/finish?email=test@example.com",
+		bytes.NewBuffer([]byte(`{"id":"cred-1"}`)),
+	)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "capstone",
       "version": "0.0.0",
       "dependencies": {
+        "@simplewebauthn/browser": "^13.3.0",
         "@tailwindcss/vite": "^4.1.18",
         "axios": "1.13.5",
         "framer-motion": "^12.23.26",
@@ -1313,6 +1314,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@simplewebauthn/browser": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
+      "integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==",
+      "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@simplewebauthn/browser": "^13.3.0",
     "@tailwindcss/vite": "^4.1.18",
     "axios": "1.13.5",
     "framer-motion": "^12.23.26",

--- a/frontend/src/components/profile/MfaSetupModal.jsx
+++ b/frontend/src/components/profile/MfaSetupModal.jsx
@@ -2,7 +2,8 @@ import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import QRCode from "qrcode";
 import ErrorAlert from "../ErrorAlert";
-import { getMfaSetup, saveAuthenticator } from "../../services/userMfa";
+import { beginPasskeyRegistration, finishPasskeyRegistration, getMfaSetup, saveAuthenticator } from "../../services/userMfa";
+import { createPasskeyCredential } from "../../utils/webAuthn";
 
 const EMPTY_CODE = ["", "", "", "", "", ""];
 
@@ -46,15 +47,12 @@ function PasskeyIcon() {
     );
 }
 
-function ConnectionOptionButton({ title, description, icon, onClick, disabled = false, badge = "" }) {
+function ConnectionOptionButton({ title, description, icon, onClick, disabled = false }) {
     return (
         <button type="button" className="mfa-connection-option" onClick={onClick} disabled={disabled}>
             <span className="mfa-connection-option__icon">{icon}</span>
             <span className="mfa-connection-option__content">
-                <span className="mfa-connection-option__title-row">
-                    <span className="mfa-connection-option__title">{title}</span>
-                    {badge && <span className="mfa-connection-option__badge">{badge}</span>}
-                </span>
+                <span className="mfa-connection-option__title">{title}</span>
                 <span className="mfa-connection-option__description">{description}</span>
             </span>
         </button>
@@ -73,6 +71,7 @@ export default function MfaSetupModal({ isOpen, email, onClose, onSaved }) {
     const [errorMessage, setErrorMessage] = useState("");
     const [isLoadingSetup, setIsLoadingSetup] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
+    const [isRegisteringPasskey, setIsRegisteringPasskey] = useState(false);
 
     useEffect(() => {
         if (!isOpen) {
@@ -86,6 +85,7 @@ export default function MfaSetupModal({ isOpen, email, onClose, onSaved }) {
             setErrorMessage("");
             setIsLoadingSetup(false);
             setIsSaving(false);
+            setIsRegisteringPasskey(false);
             return;
         }
 
@@ -239,8 +239,22 @@ export default function MfaSetupModal({ isOpen, email, onClose, onSaved }) {
         setStep("scan");
     };
 
-    const handleSelectPasskey = () => {
-        setErrorMessage("Passkey setup is not available in One Portal yet.");
+    const handleSelectPasskey = async () => {
+        setErrorMessage("");
+        setIsRegisteringPasskey(true);
+
+        try {
+            const options = await beginPasskeyRegistration(email);
+            const credential = await createPasskeyCredential(options);
+
+            await finishPasskeyRegistration(email, credential);
+            await onSaved?.();
+            onClose();
+        } catch (error) {
+            setErrorMessage(error.message || "Failed to register passkey.");
+        } finally {
+            setIsRegisteringPasskey(false);
+        }
     };
 
     if (!isOpen) {
@@ -295,14 +309,14 @@ export default function MfaSetupModal({ isOpen, email, onClose, onSaved }) {
                                     description="Scan a QR code and verify a 6-digit code."
                                     icon={<AuthenticatorAppIcon />}
                                     onClick={handleSelectAuthenticatorApp}
+                                    disabled={isRegisteringPasskey}
                                 />
                                 <ConnectionOptionButton
                                     title="Passkey"
-                                    description="Use your device, browser, or security key."
+                                    description={isRegisteringPasskey ? "Creating passkey..." : "Use your device, browser, or security key."}
                                     icon={<PasskeyIcon />}
                                     onClick={handleSelectPasskey}
-                                    disabled
-                                    badge="Not Available"
+                                    disabled={isRegisteringPasskey}
                                 />
                             </div>
                         )}

--- a/frontend/src/services/userMfa.js
+++ b/frontend/src/services/userMfa.js
@@ -133,6 +133,26 @@ export async function saveAuthenticator({ email, secret, code, name }) {
     };
 }
 
+export function beginPasskeyRegistration(email) {
+    return userMfaRequest("/mfa/passkey/register/begin", {
+        method: "POST",
+        data: {
+            email: readTextValue(email),
+        },
+    });
+}
+
+export async function finishPasskeyRegistration(email, credential) {
+    const response = await userMfaRequest(`/mfa/passkey/register/finish?email=${encodeURIComponent(email)}`, {
+        method: "POST",
+        data: credential,
+    });
+
+    clearAuthenticatorListCache(email);
+
+    return response;
+}
+
 export async function verifyMfaCode({ email, code }) {
     return userMfaRequest("/mfa/verify", {
         method: "POST",

--- a/frontend/src/styles/Mfa.css
+++ b/frontend/src/styles/Mfa.css
@@ -434,35 +434,11 @@
   gap: 0.35rem;
 }
 
-.mfa-connection-option__title-row {
-  display: flex;
-  align-items: center;
-  gap: 0.65rem;
-  min-width: 0;
-}
-
 .mfa-connection-option__title {
   color: var(--profile-text);
   font-size: 1rem;
   font-weight: 800;
   line-height: 1.2;
-}
-
-.mfa-connection-option__badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 1.45rem;
-  padding: 0.2rem 0.55rem;
-  border: 1px solid rgba(250, 204, 21, 0.58);
-  border-radius: 999px;
-  color: #facc15;
-  background: rgba(23, 32, 51, 0.24);
-  font-size: 0.68rem;
-  font-weight: 800;
-  line-height: 1;
-  text-transform: uppercase;
-  white-space: nowrap;
 }
 
 .mfa-connection-option__description {

--- a/frontend/src/utils/webAuthn.js
+++ b/frontend/src/utils/webAuthn.js
@@ -1,0 +1,11 @@
+import { startRegistration } from "@simplewebauthn/browser";
+
+function getPublicKeyOptions(options = {}) {
+    return options.publicKey || options;
+}
+
+export function createPasskeyCredential(options) {
+    return startRegistration({
+        optionsJSON: getPublicKeyOptions(options),
+    });
+}


### PR DESCRIPTION
This pull request adds full support for passkey-based multi-factor authentication (MFA) to both the backend and frontend. It introduces new backend API endpoints for passkey registration and verification, adds the necessary data transfer objects, and implements comprehensive tests. On the frontend, it integrates the passkey registration flow using the WebAuthn API via the `@simplewebauthn/browser` package, and updates the MFA setup modal to allow users to register a passkey as a second factor.

The most important changes are:

**Backend: Passkey MFA API Implementation**
- Added new endpoints for passkey registration and verification to the backend (`/passkey/register/begin`, `/passkey/register/finish`, `/passkey/verify/begin`, `/passkey/verify/finish`, `/passkey/exists`) in `routes.go` and implemented their handlers in `mfa_handler.go`. [[1]](diffhunk://#diff-f6343594ca58b3a83e23fc4a6c8056458ca9085fd8fbed0518bcf8405891e07aR81-R109) [[2]](diffhunk://#diff-b3ee6c05fecfd6aeb02a83740e9a1156ab2fede07caa711a621cda6fb11b6394R418-R764)
- Introduced the `PasskeyBeginRequest` DTO to facilitate passkey ceremonies.

**Backend: Testing**
- Added unit tests for all new passkey-related handler endpoints to ensure correct behavior and integration with the identity provider service.

**Frontend: Passkey Registration Flow**
- Added the `@simplewebauthn/browser` package for WebAuthn support and integrated passkey registration into the `MfaSetupModal` component. This includes backend communication, credential creation, and error handling. [[1]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR11) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR1318-R1323) [[3]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R13) [[4]](diffhunk://#diff-2d458b405289c55c173384cc1a90d96f0bcd2e35994a6ac44c0e8d03367423d2L5-R6) [[5]](diffhunk://#diff-2d458b405289c55c173384cc1a90d96f0bcd2e35994a6ac44c0e8d03367423d2L242-R257)

**Frontend: UI/UX Improvements**
- Updated the MFA setup modal to support passkey registration, including loading states and error messages during the registration process. The passkey option is now enabled and functional. [[1]](diffhunk://#diff-2d458b405289c55c173384cc1a90d96f0bcd2e35994a6ac44c0e8d03367423d2R74) [[2]](diffhunk://#diff-2d458b405289c55c173384cc1a90d96f0bcd2e35994a6ac44c0e8d03367423d2R88) [[3]](diffhunk://#diff-2d458b405289c55c173384cc1a90d96f0bcd2e35994a6ac44c0e8d03367423d2R312-R319) [[4]](diffhunk://#diff-2d458b405289c55c173384cc1a90d96f0bcd2e35994a6ac44c0e8d03367423d2L49-L57)

These changes together enable users to register and use passkeys for MFA, enhancing both security and user experience.